### PR TITLE
Fix default adxl345 spi_bus for octopus

### DIFF
--- a/boards/btt-octopus-11/config.cfg
+++ b/boards/btt-octopus-11/config.cfg
@@ -44,5 +44,5 @@ min_temp: 0
 max_temp: 100
 
 [adxl345]
-spi_bus: spi3a
+spi_bus: spi3
 cs_pin: adxl345_cs_pin


### PR DESCRIPTION
The spi header on the octopus is SPI3[1] (pins PB3,PB4,PB5 on stm32, see for example kipper's spi.c [2]).
On the octopus, spi3a is used for the sdio header.

[1] https://raw.githubusercontent.com/bigtreetech/BIGTREETECH-OCTOPUS-V1.0/master/Hardware/BIGTREETECH%20Octopus%20-%20PIN.pdf
[2] https://github.com/KevinOConnor/klipper/blob/master/src/stm32/spi.c