### PR TITLE
Fix SKR Pro 1.2 make-and-flash-mcu.sh firmware config copy

### DIFF
--- a/boards/btt-skr-pro-12/make-and-flash-mcu.sh
+++ b/boards/btt-skr-pro-12/make-and-flash-mcu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cp -f /home/pi/klipper_config/config/boards/btt-octopus-11/firmware.config /home/pi/klipper/.config
+cp -f /home/pi/klipper_config/config/boards/btt-skr-pro-12/firmware.config /home/pi/klipper/.config
 cd /home/pi/klipper
 make olddefconfig
 make clean


### PR DESCRIPTION
Hey there, I fixed the firmware.config path error in the make-and-flash-mcu.sh script for the SKR Pro 1.2 as I mentioned yesterday on discord!