### PR TITLE
Replace timout gcode to keep motors on when paused

### DIFF
--- a/printers/v-core-3/v-core-3.cfg
+++ b/printers/v-core-3/v-core-3.cfg
@@ -43,3 +43,12 @@ path: ~/gcode_files
 [display_status]
 
 [pause_resume]
+
+[idle_timeout]
+gcode:
+  {% if printer.pause_resume.is_paused %}
+    M104 S0
+  {% else %}
+    TURN_OFF_HEATERS
+    M84
+  {% endif %}

--- a/printers/v-minion/v-minion.cfg
+++ b/printers/v-minion/v-minion.cfg
@@ -53,3 +53,12 @@ fade_end: 10.0
 mesh_pps: 2,2
 algorithm: bicubic
 bicubic_tension: .2
+
+[idle_timeout]
+gcode:
+  {% if printer.pause_resume.is_paused %}
+    M104 S0
+  {% else %}
+    TURN_OFF_HEATERS
+    M84
+  {% endif %}


### PR DESCRIPTION
This PR will make sure klipper does not disable the motors when a print is paused. Doing so will cause major issues as it would require a rehome using some CNC kitchen trickery. After elliot mentioned the issue on discord I figured we should fix this in the base config asap. 