### PR TITLE
Add ability to home each axis

### DIFF
--- a/templates/sensorless-homing.cfg
+++ b/templates/sensorless-homing.cfg
@@ -23,35 +23,37 @@ diag_pin: y_diag_pin
 driver_SGTHRS: 70 # Stall guard threshold, this is your Y sensitivity, to adjust, copy this section and override it in printer.cfg.
 
 [homing_override]
-set_position_z: 5
 gcode:
     M400                  # Wait for moves to finish
-    G90                   # Absolute positioning
-    G0 Z10 F600           # Hop Z-Axis
     M204 S1000            # Set homing acceleration (important!)
-
+    {% set home_all = params.X is not defined and params.Y is not defined and params.Z is not defined %}
+    {% if params.Y is defined or home_all %}
     # Home Y
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.4 HOLDCURRENT=0.4
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.4 HOLDCURRENT=0.4
     G28 Y
     G0 Y{printer.toolhead.axis_maximum.y / 2} F9000
+    {% endif %}
 
+    {% if params.X is defined or home_all %}
     # Home X
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.5 HOLDCURRENT=0.5
-    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.5 HOLDCURRENT=0.5
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.4 HOLDCURRENT=0.4
+    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.4 HOLDCURRENT=0.4
     G28 X
 
     G0 X{printer.toolhead.axis_maximum.x / 2} F9000
- 
+    {% endif %}
+    
     # Restore current
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.config["tmc2209 stepper_x"].run_current} HOLDCURRENT={printer.configfile.config["tmc2209 stepper_x"].hold_current}
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.config["tmc2209 stepper_y"].run_current} HOLDCURRENT={printer.configfile.config["tmc2209 stepper_y"].hold_current}
-
-	G0 X{printer.toolhead.axis_maximum.x / 2} Y{printer.toolhead.axis_maximum.y / 2} F3000
+    
+    {% if params.Z is defined or home_all %}
+    G0 X{printer.toolhead.axis_maximum.x / 2} Y{printer.toolhead.axis_maximum.y / 2} F3000
 	
     # Rehome Z
     G28 Z
     
     # Safe Z
     G0 Z10 F600
-    
+    {% endif %}


### PR DESCRIPTION
This removes the blind Z hop of 10 mm making sure that you do not hit the endstop but allows you now to home X Y and Z separately.
SET_TMC_CURRENT is now also consistent with 0.4A for both X and Y homing