### PR TITLE
Correct _PARK macro variable check

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -114,7 +114,7 @@ gcode:
 gcode:
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Get X position
-  {% if params.X is defined %}
+  {% if params.X != '' %}
     {% if params.X|float >= printer.toolhead.axis_minimum.x + 5 and params.X|float <= printer.toolhead.axis_maximum.x - 5 %}
       {% set safe_x = params.X|float %}
     {% else %}


### PR DESCRIPTION
Corrects the `_PARK` macro check for the `X` parameter being defined so that the warning message is not printed to the terminal when `X` is not specified