### PR TITLE
Fix to make pin mappings match the diagrams

### DIFF
--- a/boards/btt-octopus-pro-446/config.cfg
+++ b/boards/btt-octopus-pro-446/config.cfg
@@ -18,9 +18,9 @@ aliases:
   bltouch_sensor_pin=PB7,  bltouch_control_pin=PB6,
   probe_pin=PB7,
 # fans
-  fan_part_cooling_pin=PA8,
-  fan_toolhead_cooling_pin=PE5,
-  fan_controller_board_pin=PD12,
+  fan_part_cooling_pin=PE5,
+  fan_toolhead_cooling_pin=PD12,
+  fan_controller_board_pin=PD13,
 # Bed heater
   heater_bed_heating_pin=PA1,
   heater_bed_sensor_pin=PF3,


### PR DESCRIPTION
This change makes the pin mappings match what's illustrated on the diagram https://github.com/Rat-OS/RatOS-configuration/blob/master/boards/btt-octopus-pro-446/v-core-3-wiring.png
