### PR TITLE
Update macros.cfg

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -169,8 +169,10 @@ gcode:
   G0 E5 F3600
   # Extract back fast in to the cold zone 
   G0 E-15 F3600
+  # Pass the metall tube very slowly to prevent PETG heat creep       
+  G0 E-30 F100
   # Continue extraction slowly, allow the filament time to cool solid before it reaches the gears       
-  G0 E-130 F300
+  G0 E-100 F300
   M117 Filament unloaded!
   RESTORE_GCODE_STATE NAME=unload_state
 


### PR DESCRIPTION
Extracting PETG filament too fast, out of hotends with metall cooling tubes, can cause heat creep. Passing the filament verry slowly through the metall tube seems to help a lot.