### PR TITLE
Add RatOS variable "end_print_additional_z_gap"

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -22,6 +22,7 @@ variable_nozzle_priming: "primeline"
 variable_start_print_park_in: "back"
 variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
+variable_end_print_additional_z_gap: 0
 variable_pause_print_park_in: "back"
 variable_macro_travel_speed: 150
 gcode:
@@ -334,3 +335,20 @@ gcode:
 [gcode_macro _END_PRINT_PARK]
 gcode:
   _PARK LOCATION={printer["gcode_macro RatOS"].end_print_park_in} X={printer["gcode_macro RatOS"].end_print_park_x}
+  SAVE_GCODE_STATE NAME=end_print_drop
+  # Calculate safe Z move
+  {% set max_z = printer.toolhead.axis_maximum.z|float %}
+  {% set act_z = printer.toolhead.position.z|float %}
+  {% if act_z < (max_z - printer["gcode_macro RatOS"].end_print_additional_z_gap|float) %}
+    {% set z_move = printer["gcode_macro RatOS"].end_print_additional_z_gap|float %}
+  {% else %}
+    {% set z_move = max_z - act_z %}
+  {% endif %}
+  # Relative positioning
+  G91
+  #
+  G1 Z{z_move} F3600
+  RESTORE_GCODE_STATE NAME=end_print_drop
+
+
+

--- a/macros.cfg
+++ b/macros.cfg
@@ -22,7 +22,7 @@ variable_nozzle_priming: "primeline"
 variable_start_print_park_in: "back"
 variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
-variable_end_print_additional_z_gap: 0
+variable_end_print_relative_z: 0
 variable_pause_print_park_in: "back"
 variable_macro_travel_speed: 150
 gcode:
@@ -231,6 +231,7 @@ gcode:
   # Run the customizable "PARK" macro
   _START_PRINT_PARK
   # Wait for extruder to heat up
+  M117 Heating extruder...
   M109 S{params.EXTRUDER_TEMP|default(printer.extruder.target, true) }
   # Run the customizable "AFTER_HEATING_EXTRUDER" macro.
   _START_PRINT_AFTER_HEATING_EXTRUDER
@@ -339,8 +340,8 @@ gcode:
   # Calculate safe Z move
   {% set max_z = printer.toolhead.axis_maximum.z|float %}
   {% set act_z = printer.toolhead.position.z|float %}
-  {% if act_z < (max_z - printer["gcode_macro RatOS"].end_print_additional_z_gap|float) %}
-    {% set z_move = printer["gcode_macro RatOS"].end_print_additional_z_gap|float %}
+  {% if act_z < (max_z - printer["gcode_macro RatOS"].end_print_relative_z|float) %}
+    {% set z_move = printer["gcode_macro RatOS"].end_print_relative_z|float %}
   {% else %}
     {% set z_move = max_z - act_z %}
   {% endif %}

--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -155,7 +155,7 @@ variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
 # Drop the bed by this amount after the end of the print for easier flexplate
 # removal. Set to 0 to disable.
-variable_end_print_additional_z_gap: 100
+variable_end_print_relative_z: 100
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"

--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -153,6 +153,9 @@ variable_start_print_park_z_height: 50
 # Park in the back after the print has ended or was cancelled.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_end_print_park_in: "back"
+# Drop the bed by this amount after the end of the print for easier flexplate
+# removal. Set to 0 to disable.
+variable_end_print_additional_z_gap: 100
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"

--- a/templates/v-core-pro-printer.template.cfg
+++ b/templates/v-core-pro-printer.template.cfg
@@ -148,6 +148,9 @@ variable_start_print_park_z_height: 50
 # Park in the back after the print has ended or was cancelled.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_end_print_park_in: "back"
+# Drop the bed by this amount after the end of the print for easier flexplate
+# removal. Set to 0 to disable.
+variable_end_print_additional_z_gap: 100
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"

--- a/templates/v-core-pro-printer.template.cfg
+++ b/templates/v-core-pro-printer.template.cfg
@@ -150,7 +150,7 @@ variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
 # Drop the bed by this amount after the end of the print for easier flexplate
 # removal. Set to 0 to disable.
-variable_end_print_additional_z_gap: 100
+variable_end_print_relative_z: 100
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"

--- a/templates/v-minion-printer.template.cfg
+++ b/templates/v-minion-printer.template.cfg
@@ -158,6 +158,9 @@ variable_start_print_park_z_height: 50
 # Park in the back after the print has ended or was cancelled.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_end_print_park_in: "back"
+# Raise the head by this amount after the end of the print for easier flexplate
+# removal. Set to 0 to disable.
+variable_end_print_additional_z_gap: 0
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "front"

--- a/templates/v-minion-printer.template.cfg
+++ b/templates/v-minion-printer.template.cfg
@@ -160,7 +160,7 @@ variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
 # Raise the head by this amount after the end of the print for easier flexplate
 # removal. Set to 0 to disable.
-variable_end_print_additional_z_gap: 0
+variable_end_print_relative_z: 0
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "front"


### PR DESCRIPTION
Set a user definable additional z-gap between the print head and bed at the end of print for easier flexplate removal.