### PR TITLE
Fix typo in COMPILE_FIRMWARE macro name

### DIFF
--- a/shell-macros.cfg
+++ b/shell-macros.cfg
@@ -41,7 +41,7 @@ gcode:
         RESPOND MSG="Input shaper graphs generated for X and Y. You'll find them in the input_shaper folder in the machine tab!"
     {% endif %}
 
-[gcode_macro COMPILE_FIRMARE]
+[gcode_macro COMPILE_FIRMWARE]
 gcode:
     RESPOND MSG="Compiling binaries.. This can take up to 10 minutes. Please do not turn off your Raspberry Pi!"
     RUN_SHELL_COMMAND CMD=compile_binaries


### PR DESCRIPTION
Just a simple fix for a typo