### PR TITLE
Add prime blob macro

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -109,6 +109,40 @@ gcode:
   G1 Y{printer.toolhead.axis_minimum.y + 100} F{speed}
   # Reset extrusion
   G92 E0
+
+[gcode_macro PRIME_BLOB]
+gcode:
+  {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+  # Absolute positioning
+  G90 
+  # Absolute extrusion
+  M82
+  M117 Prime blob...
+  # Lift 5 mm
+  G1 Z5 F3000
+  # Reset extrusion distance
+  G92 E0
+  # move to blob position
+  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + 10} Z0.5 F{speed}
+  # Extrude a blob
+  G1 F60 E20
+  # 40% fan
+  M106 S102 
+  # Move the extruder up by 5mm while extruding, breaks away from blob
+  G1 Z5 F100 E25
+  # Move to wipe position, but keep extruding so the wipe is attached to blob
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E26 
+  # Go down diagonally while extruding
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 40} Z0.2 E28 
+  # 0% fan
+  M106 S0
+  # small wipe line
+  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E28.6 
+  # Break away wipe
+  G1 F{speed} Y{printer.toolhead.axis_minimum.y + 100}
+  # Reset extrusion distance
+  G92 E0
+
   
 [gcode_macro _PARK]
 gcode:
@@ -275,6 +309,9 @@ gcode:
 gcode:
   {% if printer["gcode_macro RatOS"].nozzle_priming|lower == 'primeline' %}
     PRIME_LINE
+  {% endif %}
+  {% if printer["gcode_macro RatOS"].nozzle_priming|lower == 'primeblob' %}
+    PRIME_BLOB
   {% endif %}
   {% if printer["gcode_macro RatOS"].skew_profile is defined %}
     SKEW_PROFILE LOAD={printer["gcode_macro RatOS"].skew_profile}

--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -139,8 +139,8 @@ variable_preheat_extruder: True
 # with the name "ratos", be sure to save your bed_mesh profile with that name.
 # or override the _START_PRINT_BED_MESH macro to implement your own mesh handling logic.
 variable_calibrate_bed_mesh: True
-# Print a prime line at the end of the START_PRINT macro
-# set to False to disable nozzle_priming.
+# Print a prime line or blob at the end of the START_PRINT macro
+# set to "primeline" or "primeblob", or False to disable nozzle_priming.
 variable_nozzle_priming: "primeline"
 # Park in the back when waiting for the extruder to heat up
 # set to "front" to park in the front, or "center" to park in the center.


### PR DESCRIPTION
This adds a new priming option that I have been using for a while now.

- It starts 0.5mm above the bed and extrudes a blob that is intended to wrap around the nozzle. This catches any ooze sticking to the nozzle.
- It enables the fan and slowly moves up, pulling the nozzle out of the blob, leaving oozy bits behind. Nozzle should be clean now.
- While it moves up, backwards and down again, it keeps extruding in mid-air.
- It extrudes a small wipe line and breaks away from it.
- The blob, mid-air extrusion and line are all attached to each other, so they are very easy to pluck off the bed. You won't get filament under your fingernails, like when you try to pry off a wipe line.