### PR TITLE
Primeblob tuning tower workaround

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -134,10 +134,10 @@ gcode:
   # Go down diagonally while extruding
   # Broken down in z moves under 2mm as a workaround for a tuning tower test.
   # The tuning tower command thinks a new print has been started when z moves over 2mm and aborts.
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 10} Z3.8 E0.5
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 20} Z2.6 E0.5
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 30} Z1.4 E0.5
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 40} Z0.2 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 30} Z3.8 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 35} Z2.6 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 40} Z1.4 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 45} Z0.2 E0.5
   # 0% fan
   M106 S0
   # small wipe line

--- a/macros.cfg
+++ b/macros.cfg
@@ -89,6 +89,7 @@ gcode:
 
 [gcode_macro PRIME_LINE]
 gcode:
+  SAVE_GCODE_STATE NAME=prime_line_state
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Absolute positioning
   G90 
@@ -107,21 +108,19 @@ gcode:
   G1 Y{printer.toolhead.axis_minimum.y + 80} E16 F1200
   # Wipe
   G1 Y{printer.toolhead.axis_minimum.y + 100} F{speed}
-  # Reset extrusion
-  G92 E0
+  RESTORE_GCODE_STATE NAME=prime_line_state
 
 [gcode_macro PRIME_BLOB]
 gcode:
+  SAVE_GCODE_STATE NAME=prime_blob_state
+  M117 Prime blob...
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Absolute positioning
   G90 
-  # Absolute extrusion
-  M82
-  M117 Prime blob...
+  # Relative extrusion
+  M83
   # Lift 5 mm
   G1 Z5 F3000
-  # Reset extrusion distance
-  G92 E0
   # move to blob position
   G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + 10} Z0.5 F{speed}
   # Extrude a blob
@@ -129,19 +128,23 @@ gcode:
   # 40% fan
   M106 S102 
   # Move the extruder up by 5mm while extruding, breaks away from blob
-  G1 Z5 F100 E25
+  G1 Z5 F100 E5  
   # Move to wipe position, but keep extruding so the wipe is attached to blob
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E26 
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E1 
   # Go down diagonally while extruding
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 40} Z0.2 E28 
+  # Broken down in z moves under 2mm as a workaround for a tuning tower test.
+  # The tuning tower command thinks a new print has been started when z moves over 2mm and aborts.
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 10} Z3.8 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 20} Z2.6 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 30} Z1.4 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 40} Z0.2 E0.5
   # 0% fan
   M106 S0
   # small wipe line
-  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E28.6 
+  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E0.6 
   # Break away wipe
   G1 F{speed} Y{printer.toolhead.axis_minimum.y + 100}
-  # Reset extrusion distance
-  G92 E0
+  RESTORE_GCODE_STATE NAME=prime_blob_state
 
   
 [gcode_macro _PARK]


### PR DESCRIPTION
Splits z-move down while extruding in multiple moves under 2 mm to avoid a tuning tower test to be cancelled.