### PR TITLE
M118 | Homing | ABL | MQTT

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -288,6 +288,19 @@ gcode:
   _START_PRINT_PARK
   # Wait for extruder to heat up
   M109 S{params.EXTRUDER_TEMP|default(printer.extruder.target, true) }
+  {% if printer["gcode_macro RatOS"].nozzle_cleaning|lower == 'true' %}
+    M118 Clean your nozzle now, 10 seconds to start
+    G4 P5000
+    M118 Clean your nozzle now, 5 seconds to start
+    G4 P2000
+    M118 Clean your nozzle now, 3 seconds to start
+    G4 P1000
+    M118 Clean your nozzle now, 2 seconds to start
+    G4 P1000
+    M118 Clean your nozzle now, 1 seconds to start
+    G4 P1000
+    M118 Priming the nozzle
+  {% endif %}
   # Run the customizable "AFTER_HEATING_EXTRUDER" macro.
   _START_PRINT_AFTER_HEATING_EXTRUDER
   M117 Printing...
@@ -329,19 +342,6 @@ gcode:
   {% set z = printer["gcode_macro RatOS"].start_print_park_z_height|float %}
   _PARK LOCATION={printer["gcode_macro RatOS"].start_print_park_in} X={printer["gcode_macro RatOS"].start_print_park_x}
   G0 Z{z} F6000
-  {% if printer["gcode_macro RatOS"].nozzle_cleaning|lower == 'true' %}
-    M118 Clean your nozzle now, 10 seconds to start
-    G4 P5000
-    M118 Clean your nozzle now, 5 seconds to start
-    G4 P2000
-    M118 Clean your nozzle now, 3 seconds to start
-    G4 P1000
-    M118 Clean your nozzle now, 2 seconds to start
-    G4 P1000
-    M118 Clean your nozzle now, 1 seconds to start
-    G4 P1000
-    M118 Priming the nozzle
-  {% endif %}
 
 [gcode_macro _START_PRINT_AFTER_HEATING_EXTRUDER]
 gcode:

--- a/macros.cfg
+++ b/macros.cfg
@@ -23,6 +23,8 @@ variable_start_print_park_in: "back"
 variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
 variable_pause_print_park_in: "back"
+variable_nozzle_cleaning: True
+variable_mqtt_alerts: True
 variable_macro_travel_speed: 150
 gcode:
   ECHO_RATOS_VARS
@@ -35,6 +37,9 @@ gcode:
 rename_existing: PAUSE_BASE
 variable_extrude: 1.5
 gcode:
+  {% if printer["gcode_macro RatOS"].mqtt_alerts|lower == 'true' %}
+    PUBLISH_ALERT PAYLOAD=PAUSE
+  {% endif %}
   SAVE_GCODE_STATE NAME=PAUSE_state
   # Define park positions 
   {% set E = printer["gcode_macro PAUSE"].extrude|float %}
@@ -66,6 +71,9 @@ gcode:
 [gcode_macro RESUME]
 rename_existing: RESUME_BASE
 gcode:
+  {% if printer["gcode_macro RatOS"].mqtt_alerts|lower == 'true' %}
+    PUBLISH_ALERT PAYLOAD=RESUME
+  {% endif %}
   {% set E = printer["gcode_macro PAUSE"].extrude|float %}
   # Prime
   {% if printer.extruder.can_extrude|lower == 'true' %}
@@ -81,6 +89,9 @@ gcode:
 [gcode_macro CANCEL_PRINT]
 rename_existing: CANCEL_PRINT_BASE
 gcode:
+  {% if printer["gcode_macro RatOS"].mqtt_alerts|lower == 'true' %}
+    PUBLISH_ALERT PAYLOAD=CANCEL
+  {% endif %}
   END_PRINT
   TURN_OFF_HEATERS
   CLEAR_PAUSE
@@ -186,6 +197,9 @@ gcode:
 
 [gcode_macro UNLOAD_FILAMENT]
 gcode:
+  {% if printer["gcode_macro RatOS"].mqtt_alerts|lower == 'true' %}
+    PUBLISH_ALERT PAYLOAD=FILAMENT_UNLOAD
+  {% endif %}
   SAVE_GCODE_STATE NAME=unload_state
   G91
   {% if params.TEMP is defined or printer.extruder.can_extrude|lower == 'false' %}
@@ -242,6 +256,9 @@ gcode:
 
 [gcode_macro START_PRINT]
 gcode:
+  {% if printer["gcode_macro RatOS"].mqtt_alerts|lower == 'true' %}
+    PUBLISH_ALERT PAYLOAD=PRINT_STARTED
+  {% endif %}
   CLEAR_PAUSE
   SAVE_GCODE_STATE NAME=start_print_state
   # Metric values
@@ -250,9 +267,15 @@ gcode:
   G90 
   # Set extruder to absolute mode
   M82
-  # Home 
-  G28
+  # Home if it wasn't homed before
+  {% if printer.toolhead.homed_axes != 'xyz' %}
+    M118 Homing the printer
+    G28
+  {% else %}
+    M118 Already homed
+  {% endif %}
   M117 Heating bed...
+  M118 Heating bed...
   # Wait for bed to heat up
   M190 S{params.BED_TEMP|default(printer.heater_bed.target, true) }
   # Run the customizable "AFTER_HEATING_BED" macro.
@@ -268,6 +291,7 @@ gcode:
   # Run the customizable "AFTER_HEATING_EXTRUDER" macro.
   _START_PRINT_AFTER_HEATING_EXTRUDER
   M117 Printing...
+  M118 Printing...
   RESTORE_GCODE_STATE NAME=start_print_state
   # Set extrusion mode based on user configuration
   {% if printer["gcode_macro RatOS"].relative_extrusion|lower == 'true' %}
@@ -286,6 +310,7 @@ gcode:
 gcode:
   {% if printer["gcode_macro RatOS"].preheat_extruder|lower == 'true' %}
     M117 Pre-heating extruder...
+    M118 Pre-heating extruder...
     # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
     # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
     M104 S150
@@ -304,6 +329,19 @@ gcode:
   {% set z = printer["gcode_macro RatOS"].start_print_park_z_height|float %}
   _PARK LOCATION={printer["gcode_macro RatOS"].start_print_park_in} X={printer["gcode_macro RatOS"].start_print_park_x}
   G0 Z{z} F6000
+  {% if printer["gcode_macro RatOS"].nozzle_cleaning|lower == 'true' %}
+    M118 Clean your nozzle now, 10 seconds to start
+    G4 P5000
+    M118 Clean your nozzle now, 5 seconds to start
+    G4 P2000
+    M118 Clean your nozzle now, 3 seconds to start
+    G4 P1000
+    M118 Clean your nozzle now, 2 seconds to start
+    G4 P1000
+    M118 Clean your nozzle now, 1 seconds to start
+    G4 P1000
+    M118 Priming the nozzle
+  {% endif %}
 
 [gcode_macro _START_PRINT_AFTER_HEATING_EXTRUDER]
 gcode:
@@ -326,6 +364,9 @@ gcode:
 # The end_print macro is also called from CANCEL_PRINT.
 [gcode_macro END_PRINT]
 gcode:
+  {% if printer["gcode_macro RatOS"].mqtt_alerts|lower == 'true' %}
+    PUBLISH_ALERT PAYLOAD=PRINT_FINISHED
+  {% endif %}
   SAVE_GCODE_STATE NAME=end_print_state
   # Extruder heater off
   M104 S0
@@ -338,10 +379,13 @@ gcode:
     SET_SKEW CLEAR=1
   {% endif %}
   # Steppers off
-  M84
+  {% if printer["gcode_macro RatOS"].motors_off|lower == 'true' %}
+    M84
+  {% endif %}
   # Part cooling fan off
   M107
   M117 Done.
+  M118 Done.
   RESTORE_GCODE_STATE NAME=end_print_state
 
 #####
@@ -371,3 +415,13 @@ gcode:
 [gcode_macro _END_PRINT_PARK]
 gcode:
   _PARK LOCATION={printer["gcode_macro RatOS"].end_print_park_in} X={printer["gcode_macro RatOS"].end_print_park_x}
+
+[gcode_macro PUBLISH_ALERT]
+gcode:
+  {% set data = params.PAYLOAD|default(None) %}
+  {action_call_remote_method("publish_mqtt_topic",
+                             topic="klipper/gcode",
+                             payload=data,
+                             qos=0,
+                             retain=False,
+                             use_prefix=True)}

--- a/printers/base.cfg
+++ b/printers/base.cfg
@@ -7,6 +7,7 @@ gcode:
   {% if printer.webhooks.state|lower == 'ready' %}
     {% if printer.pause_resume.is_paused|lower == 'false' %}
       M117 Idle timeout reached
+      M118 Idle timeout reached
       TURN_OFF_HEATERS
       M84
     {% endif %}

--- a/printers/v-core-3/macros.cfg
+++ b/printers/v-core-3/macros.cfg
@@ -9,14 +9,19 @@
 gcode:
   {% if printer["gcode_macro RatOS"].preheat_extruder|lower == 'true' %}
   M117 Pre-heating extruder...
+  M118 Pre-heating extruder...
   # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
   # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
   M104 S150
   TEMPERATURE_WAIT SENSOR=extruder MINIMUM=150
   {% endif %}
   M117 Adjusting for tilt...
-  # Adjust bed tilt
-  Z_TILT_ADJUST
+  M118 Adjusting for tilt...
+  # Adjust bed tilt if it wasn't done before
+  {% if not printer.z_tilt.applied %}
+    Z_TILT_ADJUST
+  {% endif %}
   M117 Rehoming after tilt adjustment...
+  M118 Rehoming after tilt adjustment...
   # Home again as Z will have changed after tilt adjustment and bed heating.
   G28 Z

--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -156,6 +156,13 @@ variable_end_print_park_in: "back"
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"
+# Should the Printhead wait on the Parkposition for 10 sec for Cleaning the Nozzle before starting the print
+variable_nozzle_cleaning: True
+# Is MQTT configured and you want pushmessages to be sent to MQTT broker?
+variable_mqtt_alerts: True
+# Turn the motors off after print is done
+# if turned on you don't have to home or make a z_tilt before a new printjob starts
+variable_motors_off: False
 # Set the speed for travel moves in RatOS Macros in mm/s.
 variable_macro_travel_speed: 300
 


### PR DESCRIPTION
I added some features to get the printer faster to the point where it is ready to print, especially if you print multiple prints after an other. No Homing is needed if the printer was already homed after the last time the steppers were turned off f.e.

Same for Z_TILT_ADJUST.

M118 is shown at the top of Klipper Screen, M117 not

Nozzle Cleaning Option before the print starts

MQTT => for all guys out there that use MQTT and configured it we can send messages with my additions to the broker and do what ever we want with it. F.e. let Alexa tell us that our print is done or filament runout is detected... or just a simple pushmessage via. pushover or something like this.