### PR TITLE
Add analogue for Prusa-firmware's M862.1

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -352,7 +352,7 @@ gcode:
   # Wait for extruder to heat up
   M109 S{params.EXTRUDER_TEMP|default(printer.extruder.target, true) }
   # Run the customizable "AFTER_HEATING_EXTRUDER" macro.
-  _START_PRINT_AFTER_HEATING_EXTRUDER
+  _START_PRINT_AFTER_HEATING_EXTRUDER NOZZLE_DIAMETER={params.NOZZLE_DIAMETER}
   M117 Printing...
   RESPOND MSG="Printing..."
   RESTORE_GCODE_STATE NAME=start_print_state
@@ -396,7 +396,7 @@ gcode:
 [gcode_macro _START_PRINT_AFTER_HEATING_EXTRUDER]
 gcode:
   {% if printer["gcode_macro RatOS"].nozzle_priming|lower == 'primeline' %}
-    PRIME_LINE
+    PRIME_LINE NOZZLE_DIAMETER={params.NOZZLE_DIAMETER}
   {% endif %}
   {% if printer["gcode_macro RatOS"].nozzle_priming|lower == 'primeblob' %}
     PRIME_BLOB

--- a/macros.cfg
+++ b/macros.cfg
@@ -12,7 +12,7 @@ gcode:
   {% for var, value in printer["gcode_macro RatOS"].items() %}
     {action_respond_info(var ~ ": " ~ value)}
   {% endfor %}
-  
+
 [gcode_macro RatOS]
 description: RatOS variable storage macro, will echo variables to the console when run.
 # Configuration Defaults
@@ -90,7 +90,7 @@ rename_existing: PAUSE_BASE
 variable_extrude: 1.5
 gcode:
   SAVE_GCODE_STATE NAME=PAUSE_state
-  # Define park positions 
+  # Define park positions
   {% set E = printer["gcode_macro PAUSE"].extrude|float %}
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Calculate safe Z position
@@ -115,7 +115,7 @@ gcode:
     _PARK LOCATION={printer["gcode_macro RatOS"].pause_print_park_in} X={printer["gcode_macro RatOS"].pause_print_park_x}
   {% else %}
     {action_respond_info("Printer not homed")}
-  {% endif %} 
+  {% endif %}
 
 [gcode_macro RESUME]
 description: Resumes the print if the printer is paused.
@@ -149,7 +149,7 @@ gcode:
   SAVE_GCODE_STATE NAME=prime_line_state
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Absolute positioning
-  G90 
+  G90
   # Absolute extrusion
   M82
   M117 Priming nozzle with prime line..
@@ -162,7 +162,7 @@ gcode:
   G1 Z0.3 F3000
   # Reset extrusion distance
   G92 E0
-  # Prime nozzle 
+  # Prime nozzle
   G1 Y{printer.toolhead.axis_minimum.y + 80} E16 F1200
   # Wipe
   G1 Y{printer.toolhead.axis_minimum.y + 100} F{speed}
@@ -176,7 +176,7 @@ gcode:
   RESPOND MSG="Priming nozzle with prime blob.."
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Absolute positioning
-  G90 
+  G90
   # Relative extrusion
   M83
   # Lift 5 mm
@@ -186,11 +186,11 @@ gcode:
   # Extrude a blob
   G1 F60 E20
   # 40% fan
-  M106 S102 
+  M106 S102
   # Move the extruder up by 5mm while extruding, breaks away from blob
-  G1 Z5 F100 E5  
+  G1 Z5 F100 E5
   # Move to wipe position, but keep extruding so the wipe is attached to blob
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E1 
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E1
   # Go down diagonally while extruding
   # Broken down in z moves under 2mm as a workaround for a tuning tower test.
   # The tuning tower command thinks a new print has been started when z moves over 2mm and aborts.
@@ -201,12 +201,12 @@ gcode:
   # 0% fan
   M106 S0
   # small wipe line
-  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E0.6 
+  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E0.6
   # Break away wipe
   G1 F{speed} Y{printer.toolhead.axis_minimum.y + 100}
   RESTORE_GCODE_STATE NAME=prime_blob_state
 
-  
+
 [gcode_macro _PARK]
 gcode:
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
@@ -230,9 +230,19 @@ gcode:
     {% set y = printer.toolhead.axis_maximum.y / 2 %}
   {% endif %}
   # Absolute positioning
-  G90 
+  G90
   # Park
-  G0 X{safe_x} Y{y} F{speed} 
+  G0 X{safe_x} Y{y} F{speed}
+
+[gcode_macro ASSERT_NOZZLE_DIAMETER]
+description: Raises an error unless the configured nozzle diameter is the same as the diameter passed in.
+gcode:
+  {% set configured_diameter = printer.configfile.config.extruder.nozzle_diameter|float %}
+  {% set sliced_diameter = params.NOZZLE_DIAMETER|float %}
+  {% if configured_diameter != sliced_diameter  %}
+    M117 Aborting print due to nozzle-diameter mismatch between printer config and slicer.
+    { action_raise_error("Nozzle-diameter mismatch between printer config (%s mm) and slicer (%s mm)." % (configured_diameter, sliced_diameter)) }
+  {% endif %}
 
 #####
 # COLOR CHANGE
@@ -261,15 +271,15 @@ gcode:
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(220, true)}
   {% endif %}
   M117 Unloading filament...
-  # Extract filament to cold end area 
+  # Extract filament to cold end area
   G0 E-5 F3600
   # Wait for three seconds
   G4 P3000
-  # Push back the filament to smash any stringing 
+  # Push back the filament to smash any stringing
   G0 E5 F3600
-  # Extract back fast in to the cold zone 
+  # Extract back fast in to the cold zone
   G0 E-15 F3600
-  # Continue extraction slowly, allow the filament time to cool solid before it reaches the gears       
+  # Continue extraction slowly, allow the filament time to cool solid before it reaches the gears
   G0 E-130 F300
   M117 Filament unloaded!
   RESPOND MSG="Filament unloaded! Please inspect the tip of the filament before reloading."
@@ -306,7 +316,7 @@ gcode:
 
 #####
 # START PRINT MACROS
-# Call this from your slicer (custom g-code). 
+# Call this from your slicer (custom g-code).
 # Read more here: https://rat-rig.github.io/V-CoreOS/#/slicers
 #####
 
@@ -318,11 +328,15 @@ gcode:
   # Metric values
   G21
   # Absolute positioning
-  G90 
+  G90
   # Set extruder to absolute mode
   M82
   # Home if needed
   MAYBE_HOME
+  # Check nozzle if told to do so
+  {% if params.NOZZLE_DIAMETER %}
+    ASSERT_NOZZLE_DIAMETER NOZZLE_DIAMETER={params.NOZZLE_DIAMETER}
+  {% endif %}
   M117 Heating bed...
   RESPOND MSG="Heating bed..."
   # Wait for bed to heat up
@@ -360,7 +374,7 @@ gcode:
   {% if printer["gcode_macro RatOS"].preheat_extruder|lower == 'true' %}
     M117 Pre-heating extruder...
     RESPOND MSG="Pre-heating extruder..."
-    # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
+    # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp.
     # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
     M104 S150
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM=150
@@ -393,7 +407,7 @@ gcode:
 
 #####
 # END PRINT MACROS
-# Call this from your slicer (custom g-code). 
+# Call this from your slicer (custom g-code).
 # Read more here: https://rat-rig.github.io/V-CoreOS/#/slicers
 #####
 


### PR DESCRIPTION
This gives a new, optional parameter to START_PRINT for the nozzle diameter. SuperSlicer can provide the value for this parameter using its own template-variable substitution. Then when START_PRINT is run with the parameter specified, it will check that the specified diameter is identical to what is in the configuration. Assuming the user remembers to change their configuration when they change their nozzle-diameter, this will prevent negligent usage of incorrect nozzle-diameter in the slicer (and negligent reuse of g-codes sliced for the incorrect nozzle-diameter).

I don't know how Klipper configures IDEX or toolchangers (let alone do I possess a Klipper-powered machine with such capability), so I doubt this code will work correctly for such multitool printers with multiple different nozzle-diameters.