### PR TITLE
Make configurable the end-print park's height

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -12,7 +12,7 @@ gcode:
   {% for var, value in printer["gcode_macro RatOS"].items() %}
     {action_respond_info(var ~ ": " ~ value)}
   {% endfor %}
-  
+
 [gcode_macro RatOS]
 description: RatOS variable storage macro, will echo variables to the console when run.
 # Configuration Defaults
@@ -25,6 +25,7 @@ variable_nozzle_priming: "primeblob"
 variable_start_print_park_in: "back"
 variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
+variable_end_print_relative_z: 2.0
 variable_pause_print_park_in: "back"
 variable_macro_travel_speed: 150
 gcode:
@@ -90,7 +91,7 @@ rename_existing: PAUSE_BASE
 variable_extrude: 1.5
 gcode:
   SAVE_GCODE_STATE NAME=PAUSE_state
-  # Define park positions 
+  # Define park positions
   {% set E = printer["gcode_macro PAUSE"].extrude|float %}
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Calculate safe Z position
@@ -115,7 +116,7 @@ gcode:
     _PARK LOCATION={printer["gcode_macro RatOS"].pause_print_park_in} X={printer["gcode_macro RatOS"].pause_print_park_x}
   {% else %}
     {action_respond_info("Printer not homed")}
-  {% endif %} 
+  {% endif %}
 
 [gcode_macro RESUME]
 description: Resumes the print if the printer is paused.
@@ -149,7 +150,7 @@ gcode:
   SAVE_GCODE_STATE NAME=prime_line_state
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Absolute positioning
-  G90 
+  G90
   # Absolute extrusion
   M82
   M117 Priming nozzle with prime line..
@@ -162,7 +163,7 @@ gcode:
   G1 Z0.3 F3000
   # Reset extrusion distance
   G92 E0
-  # Prime nozzle 
+  # Prime nozzle
   G1 Y{printer.toolhead.axis_minimum.y + 80} E16 F1200
   # Wipe
   G1 Y{printer.toolhead.axis_minimum.y + 100} F{speed}
@@ -176,7 +177,7 @@ gcode:
   RESPOND MSG="Priming nozzle with prime blob.."
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
   # Absolute positioning
-  G90 
+  G90
   # Relative extrusion
   M83
   # Lift 5 mm
@@ -186,11 +187,11 @@ gcode:
   # Extrude a blob
   G1 F60 E20
   # 40% fan
-  M106 S102 
+  M106 S102
   # Move the extruder up by 5mm while extruding, breaks away from blob
-  G1 Z5 F100 E5  
+  G1 Z5 F100 E5
   # Move to wipe position, but keep extruding so the wipe is attached to blob
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E1 
+  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E1
   # Go down diagonally while extruding
   # Broken down in z moves under 2mm as a workaround for a tuning tower test.
   # The tuning tower command thinks a new print has been started when z moves over 2mm and aborts.
@@ -201,12 +202,12 @@ gcode:
   # 0% fan
   M106 S0
   # small wipe line
-  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E0.6 
+  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E0.6
   # Break away wipe
   G1 F{speed} Y{printer.toolhead.axis_minimum.y + 100}
   RESTORE_GCODE_STATE NAME=prime_blob_state
 
-  
+
 [gcode_macro _PARK]
 gcode:
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
@@ -230,9 +231,9 @@ gcode:
     {% set y = printer.toolhead.axis_maximum.y / 2 %}
   {% endif %}
   # Absolute positioning
-  G90 
+  G90
   # Park
-  G0 X{safe_x} Y{y} F{speed} 
+  G0 X{safe_x} Y{y} F{speed}
 
 #####
 # COLOR CHANGE
@@ -261,15 +262,15 @@ gcode:
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(220, true)}
   {% endif %}
   M117 Unloading filament...
-  # Extract filament to cold end area 
+  # Extract filament to cold end area
   G0 E-5 F3600
   # Wait for three seconds
   G4 P3000
-  # Push back the filament to smash any stringing 
+  # Push back the filament to smash any stringing
   G0 E5 F3600
-  # Extract back fast in to the cold zone 
+  # Extract back fast in to the cold zone
   G0 E-15 F3600
-  # Continue extraction slowly, allow the filament time to cool solid before it reaches the gears       
+  # Continue extraction slowly, allow the filament time to cool solid before it reaches the gears
   G0 E-130 F300
   M117 Filament unloaded!
   RESPOND MSG="Filament unloaded! Please inspect the tip of the filament before reloading."
@@ -306,7 +307,7 @@ gcode:
 
 #####
 # START PRINT MACROS
-# Call this from your slicer (custom g-code). 
+# Call this from your slicer (custom g-code).
 # Read more here: https://rat-rig.github.io/V-CoreOS/#/slicers
 #####
 
@@ -318,7 +319,7 @@ gcode:
   # Metric values
   G21
   # Absolute positioning
-  G90 
+  G90
   # Set extruder to absolute mode
   M82
   # Home if needed
@@ -360,7 +361,7 @@ gcode:
   {% if printer["gcode_macro RatOS"].preheat_extruder|lower == 'true' %}
     M117 Pre-heating extruder...
     RESPOND MSG="Pre-heating extruder..."
-    # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
+    # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp.
     # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
     M104 S150
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM=150
@@ -393,7 +394,7 @@ gcode:
 
 #####
 # END PRINT MACROS
-# Call this from your slicer (custom g-code). 
+# Call this from your slicer (custom g-code).
 # Read more here: https://rat-rig.github.io/V-CoreOS/#/slicers
 #####
 
@@ -430,10 +431,11 @@ gcode:
 [gcode_macro _END_PRINT_AFTER_HEATERS_OFF]
 gcode:
   # Calculate safe Z position
+  {% set desired_lift = printer["gcode_macro RatOS"].end_print_relative_z|float %}
   {% set max_z = printer.toolhead.axis_maximum.z|float %}
   {% set act_z = printer.toolhead.position.z|float %}
-  {% if act_z < (max_z - 2.0) %}
-      {% set z_safe = 2.0 %}
+  {% if act_z < (max_z - desired_lift) %}
+      {% set z_safe = desired_lift %}
   {% else %}
       {% set z_safe = max_z - act_z %}
   {% endif %}

--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -2,7 +2,7 @@
 # Rat Rig V-core 3 Klipper Config
 # Documentation: https://os.ratrig.com
 
-# The first thing you'll need to do is go through this file and comment out / uncomment 
+# The first thing you'll need to do is go through this file and comment out / uncomment
 # the files and/or settings you need.
 # You'll be able to print just fine with this config as it is, but it is recommended
 # that you follow these steps to properly calibrate your printer:
@@ -40,8 +40,8 @@
 [include config/printers/v-core-3/tmc2209.cfg]
 [include config/steppers/ldo/42sth48-2504ac/2209/24v-1.1a-*.cfg]
 
-# COOLED TMC 2209 + LDO-42STH48-2504AC 
-# This increases motor torque, positional accuracy and speed limits. 
+# COOLED TMC 2209 + LDO-42STH48-2504AC
+# This increases motor torque, positional accuracy and speed limits.
 # don't enable this before your printer is fully configured and you have a fan blowing on your stepper drivers.
 #[include config/printers/v-core-3/speed-limits-performance.cfg]
 #[include config/printers/v-core-3/tmc2209-performance.cfg]
@@ -66,7 +66,7 @@
 [include config/printers/v-core-3/physical-endstops.cfg]
 # Sensorless homing (Beware: this requires manual tinkering and does not work if your x/y stepper drivers
 # have clipped DIAG pins). It is strongly encouraged to use physical endstops if you're a beginner.
-# If you still wish to proceed, copy config/templates/sensorless-homing-tmc2209.cfg to the root directory and 
+# If you still wish to proceed, copy config/templates/sensorless-homing-tmc2209.cfg to the root directory and
 # remove the # from the line below.
 #[include sensorless-homing-tmc2209.cfg]
 
@@ -75,7 +75,7 @@
 ### PHYSICAL DIMENSIONS
 ### Pick your printer size
 #############################################################################################################
-# Remove the # from your printer size below. 
+# Remove the # from your printer size below.
 # Similarly add a # in front of [include config/printers/v-core-3/300.cfg] if you have a bigger machine.
 [include config/printers/v-core-3/300.cfg]
 #[include config/printers/v-core-3/400.cfg]
@@ -87,7 +87,7 @@
 ### Enable/disable input shaper calibration
 #############################################################################################################
 # Uncomment this next line if you have an ADXL345 connected to your control board
-#[include config/printers/v-core-3/input-shaper.cfg] 
+#[include config/printers/v-core-3/input-shaper.cfg]
 
 
 #############################################################################################################
@@ -130,12 +130,12 @@
 # Use absolute extrusion mode
 # Set to True to use relative extrusion mode
 variable_relative_extrusion: False
-# Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
+# Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp.
 # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
 # Set to False to disable
 variable_preheat_extruder: True
 # Calibrate the bed mesh in the START_PRINT macro.
-# Set to false to skip BED_MESH_CALIBRATE, it will still load the BED_MESH 
+# Set to false to skip BED_MESH_CALIBRATE, it will still load the BED_MESH
 # with the name "ratos", be sure to save your bed_mesh profile with that name.
 # or override the _START_PRINT_BED_MESH macro to implement your own mesh handling logic.
 variable_calibrate_bed_mesh: True
@@ -147,12 +147,15 @@ variable_nozzle_priming: "primeline"
 variable_start_print_park_in: "back"
 # Height to park it when waiting for extruder to heat.
 variable_start_print_park_z_height: 50
-# Skew profile to load before starting the print 
+# Skew profile to load before starting the print
 # uncomment this to use your calibrated skew correction profile.
 #variable_skew_profile: "my_skew_profile"
 # Park in the back after the print has ended or was cancelled.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_end_print_park_in: "back"
+# Drop the bed by this amount after the end of the print for easier flexplate
+# removal. Set to 0 to disable.
+variable_end_print_relative_z: 100
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"

--- a/templates/v-core-pro-printer.template.cfg
+++ b/templates/v-core-pro-printer.template.cfg
@@ -39,8 +39,8 @@
 [include config/printers/v-core-pro/tmc2209.cfg]
 [include config/steppers/ldo/42sth48-2504ac/2209/24v-1.1a-*.cfg]
 
-# COOLED TMC 2209 + LDO-42STH48-2504AC 
-# This increases motor torque, positional accuracy and speed limits. 
+# COOLED TMC 2209 + LDO-42STH48-2504AC
+# This increases motor torque, positional accuracy and speed limits.
 # don't enable this before your printer is fully configured and you have a fan blowing on your stepper drivers.
 #[include config/printers/v-core-pro/speed-limits-performance.cfg]
 #[include config/printers/v-core-pro/tmc2209-performance.cfg]
@@ -65,7 +65,7 @@
 
 # Sensorless homing (Beware: this requires manual tinkering and does not work if your x/y stepper drivers
 # have clipped DIAG pins). It is strongly encouraged to use physical endstops if you're a beginner.
-# If you still wish to proceed, copy config/templates/sensorless-homing-tmc2209.cfg to the root directory and 
+# If you still wish to proceed, copy config/templates/sensorless-homing-tmc2209.cfg to the root directory and
 # remove the # from the line below.
 #[include sensorless-homing-tmc2209.cfg]
 
@@ -85,7 +85,7 @@
 ### Enable/disable input shaper calibration
 #############################################################################################################
 # Uncomment this next line if you have an ADXL345 connected to your control board
-#[include config/printers/v-core-pro/input-shaper.cfg] 
+#[include config/printers/v-core-pro/input-shaper.cfg]
 
 
 #############################################################################################################
@@ -125,12 +125,12 @@
 # Use absolute extrusion mode
 # Set to True to use relative extrusion mode
 variable_relative_extrusion: False
-# Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
+# Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp.
 # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
 # Set to False to disable
 variable_preheat_extruder: True
 # Calibrate the bed mesh in the START_PRINT macro.
-# Set to false to skip BED_MESH_CALIBRATE, it will still load the BED_MESH 
+# Set to false to skip BED_MESH_CALIBRATE, it will still load the BED_MESH
 # with the name "ratos", be sure to save your bed_mesh profile with that name.
 # or override the _START_PRINT_BED_MESH macro to implement your own mesh handling logic.
 variable_calibrate_bed_mesh: True
@@ -142,12 +142,15 @@ variable_nozzle_priming: "primeline"
 variable_start_print_park_in: "back"
 # Height to park it when waiting for extruder to heat.
 variable_start_print_park_z_height: 50
-# Skew profile to load before starting the print 
+# Skew profile to load before starting the print
 # uncomment this to use your calibrated skew correction profile.
 #variable_skew_profile: "my_skew_profile"
 # Park in the back after the print has ended or was cancelled.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_end_print_park_in: "back"
+# Drop the bed by this amount after the end of the print for easier flexplate
+# removal. Set to 0 to disable.
+variable_end_print_relative_z: 100
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "back"

--- a/templates/v-minion-printer.template.cfg
+++ b/templates/v-minion-printer.template.cfg
@@ -2,7 +2,7 @@
 # Rat Rig V-Minion Klipper Config
 # Documentation: https://os.ratrig.com
 
-# The first thing you'll need to do is go through this file and comment out / uncomment 
+# The first thing you'll need to do is go through this file and comment out / uncomment
 # the files and/or settings you need and adjust them to your particular setup.
 # You'll be able to print just fine with this config as it is, but it is recommended
 # that you follow these steps to properly calibrate your printer:
@@ -47,8 +47,8 @@
 [include config/steppers/ldo/42sth40-1684ac/2209/24v-0.8a-*.cfg]
 
 # COOLED TMC 2209 + LDO-42STH40-1684AC
-# It is highly recommended that you enable these settings as soon as you have verified that your printer moves 
-# as expected. Actively cooled drivers are needed (ie, such as the stock V-Minion eletronics enclosure with 
+# It is highly recommended that you enable these settings as soon as you have verified that your printer moves
+# as expected. Actively cooled drivers are needed (ie, such as the stock V-Minion eletronics enclosure with
 # the fan connected)
 # These settings increase torque, precision and speed, and makes sure your motors perform to their maximum
 # potential.
@@ -75,7 +75,7 @@
 [include config/printers/v-minion/physical-endstops.cfg]
 # Sensorless homing (Beware: this requires manual tinkering and does not work if your x/y stepper drivers
 # have clipped DIAG pins). It is strongly encouraged to use physical endstops if you're a beginner.
-# If you still wish to proceed, copy config/templates/sensorless-homing.cfg to the root directory and 
+# If you still wish to proceed, copy config/templates/sensorless-homing.cfg to the root directory and
 # remove the # from the line below.
 #[include sensorless-homing.cfg]
 
@@ -87,8 +87,8 @@
 # the X and Y axis. (Use SHAPER_CALIBRATE AXIS=X and SHAPER_CALIBRATE AXIS=Y respectively).
 #[include config/printers/v-minion/input-shaper-single.cfg]
 
-# Uncomment the following line to use dual ADXL345s, one for each axis, so you can permanently 
-# attach and wire them to your printer and run SHAPER_CALIBRATE once. 
+# Uncomment the following line to use dual ADXL345s, one for each axis, so you can permanently
+# attach and wire them to your printer and run SHAPER_CALIBRATE once.
 # The second ADXL345 should be connected to your Raspberry Pi. See the wiring instructions here:
 # https://www.klipper3d.org/Measuring_Resonances.html
 # NOTE: You ONLY need to wire the ADXL345, everything else is already done for you.
@@ -135,12 +135,12 @@
 # Use absolute extrusion mode
 # Set to True to use relative extrusion mode
 variable_relative_extrusion: False
-# Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
+# Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp.
 # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
 # Set to False to disable
 variable_preheat_extruder: True
 # Calibrate the bed mesh in the START_PRINT macro.
-# Set to false to skip BED_MESH_CALIBRATE, it will still load the BED_MESH 
+# Set to false to skip BED_MESH_CALIBRATE, it will still load the BED_MESH
 # with the name "ratos", be sure to save your bed_mesh profile with that name.
 # or override the _START_PRINT_BED_MESH macro to implement your own mesh handling logic.
 variable_calibrate_bed_mesh: True
@@ -152,12 +152,15 @@ variable_nozzle_priming: "primeline"
 variable_start_print_park_in: "front"
 # Height to park it when waiting for extruder to heat.
 variable_start_print_park_z_height: 50
-# Skew profile to load before starting the print 
+# Skew profile to load before starting the print
 # uncomment this to use your calibrated skew correction profile.
 #variable_skew_profile: "my_skew_profile"
 # Park in the back after the print has ended or was cancelled.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_end_print_park_in: "back"
+# Raise the head by this amount after the end of the print for easier flexplate
+# removal. Set to 0 to disable.
+variable_end_print_relative_z: 2
 # Park in the back when the print is paused.
 # set to "front" to park in the front, or "center" to park in the center.
 variable_pause_print_park_in: "front"


### PR DESCRIPTION
Even when parking at the rear, the EVA carriage is big enough that a mere 2mm of Z separation makes the sheet removal process very precise and precarious if anything was printed near the park position (maybe there was a full sheet of objects printed, or maybe the sheet is bent such that production of a non-skewed object requires printing near its rear and/or its left).

Since this will be subjective to different people's motor skills etc.; instead of just changing the magic number, I propose factoring it out like so.