### PR TITLE
Rapido Hotend -> ATC Semitec 104NT-4-R025H42G

### DIFF
--- a/hotends/rapido.cfg
+++ b/hotends/rapido.cfg
@@ -6,7 +6,7 @@
 max_extrude_only_distance: 200
 nozzle_diameter: 0.4
 heater_pin: e_heater_pin
-sensor_type: ATC Semitec 104GT-2
+sensor_type: ATC Semitec 104NT-4-R025H42G
 sensor_pin: e_sensor_pin
 min_extrude_temp: 170
 min_temp: 0


### PR DESCRIPTION
According to the official documentation on the Phaetus website it uses the ATC Semitec 104NT-4-R025H42G sensor.
See: https://www.phaetus.com/rapido-hotend/

![image](https://user-images.githubusercontent.com/2110083/161530328-97f11250-6f71-4b73-b340-26fa92d5dbea.png)
