### PR TITLE
Let the nozzle cool to 150 before probing the bed

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -363,7 +363,7 @@ gcode:
     # Wait for extruder to reach 150 so an inductive probe (if present) is at a predictable temp. 
     # Also allows the bed heat to spread a little, and softens any plastic that might be stuck to the nozzle.
     M104 S150
-    TEMPERATURE_WAIT SENSOR=extruder MINIMUM=150
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM=150 MAXIMUM=155
   {% endif %}
 
 [gcode_macro _START_PRINT_BED_MESH]


### PR DESCRIPTION
The status quo means that when we hit this command (and when the mesh bed probing begins shortly thereafter) the nozzle might be all the way at printing temperature if it is the second of two prints that are run in quick succession (e.g. if I have a second flexplate ready to go while the first one cools).

This is bad because temperature-dependent probes will get a weird result as the probe will cool down during the probing; and because until the nozzle cools enough, plastic will ooze onto the bed during the probing.

The solution, should it be desirable, is very simple.