### PR TITLE
Factor most of the magic-numbers out of PRIME_LINE

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -148,24 +148,53 @@ description: Prints a primeline, used internally, if configured, as part of the 
 gcode:
   SAVE_GCODE_STATE NAME=prime_line_state
   {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+  {% set prime_x0 = params.X0|default(5)|float %}
+  {% set prime_y0 = params.Y0|default(5)|float %}
+  {% set prime_len = params.LENGTH|default(70)|float %}
+  {% set prime_wipe_len = params.WIPE_LENGTH|default(20)|float %}
+  {% set prime_axis = params.AXIS|default("Y") %}
+  {% if prime_axis not in "XY" %}
+    {% set prime_axis = "Y" %}
+  {% endif %}
+  {% if params.AXIS_INVERT %}
+    {% set prime_len = -prime_len %}
+    {% set prime_wipe_len = -prime_wipe_len %}
+  {% endif %}
+  # for some reason, the nozzle consistently goes cold if the entire line is
+  # ordered in a single G1, but holds true if the line is broken up into
+  # pieces; it's almost like the PID loop only runs between G1s
+  {% set prime_segments = params.SEGMENTS|default(8)|int %}
+  {% set filament_cross_section_area = 2.405281875 %} # approximately pi*1.75*1.75/4
+  {% set nozzle_diameter = params.NOZZLE_DIAMETER|default(0.4)|float %}
+  {% set prime_layer_height = nozzle_diameter * 5 / 8 %}
+  # nozzles of varying bores seem to have flats of constant wall-thickness;
+  # so if we used a percentage of nozzle-bore, then we'd be more likely to
+  # extrude past the flats, the bigger the nozzle we were being asked about.
+  # so it's unfortunate that SuperSlicer's width settings can't do
+  # what we're about to do here:
+  {% set prime_line_width = nozzle_diameter + 1.6 %}
+  {% set prime_extrudate_area = prime_layer_height * prime_line_width %}
+  {% set prime_e_per_x = prime_extrudate_area/filament_cross_section_area %}
   # Absolute positioning
-  G90 
-  # Absolute extrusion
-  M82
+  G90
+  # Relative extrusion
+  M83
   M117 Priming nozzle with prime line..
   RESPOND MSG="Priming nozzle with prime line.."
   # Lift 5 mm
   G1 Z5 F3000
   # Move to prime area
-  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + 10} F{speed}
+  G1 X{printer.toolhead.axis_minimum.x + prime_x0} Y{printer.toolhead.axis_minimum.y + prime_y0} F{speed}
   # Get ready to prime
-  G1 Z0.3 F3000
-  # Reset extrusion distance
-  G92 E0
-  # Prime nozzle 
-  G1 Y{printer.toolhead.axis_minimum.y + 80} E16 F1200
+  G1 Z{prime_layer_height} F3000
+  # Relative positioning
+  G91
+  # Prime nozzle
+  {% for i in range(prime_segments) %}
+    G1 {prime_axis}{prime_len/prime_segments} E{prime_e_per_x * prime_len/prime_segments} F1200
+  {% endfor %}
   # Wipe
-  G1 Y{printer.toolhead.axis_minimum.y + 100} F{speed}
+  G1 {prime_axis}{prime_wipe_len} F{speed}
   RESTORE_GCODE_STATE NAME=prime_line_state
 
 [gcode_macro PRIME_BLOB]


### PR DESCRIPTION
This PR allows customization of the line's origin, direction and length. Compared to the status quo, this should be a big help for the macro-customizing type of person in case they like to mindlessly fill the slicer plate with models without regard for the ~8mm of margin that the default hardcoded origin (5,10) requires. (Losing that space is honestly a bit of a bummer on the small plate of the Minion, especially coming from the Prusa world where the bed and flexplate have a few unadvertised extra millimeters in the negative-Y domain where the prime line can go without ever disturbing the printed objects.)

Additionally, this PR makes the line's E-values calculated entirely from simple physical facts, including the nozzle bore which can be passed in as a parameter if it's not 0.4mm, and the filament bore which is assumed to be 1.75 (because Jinja2 does not import the math library so instead I precomputed and hardcoded the filament's cross-sectional diameter).

Lastly, this includes a solution for an annoying problem where the nozzle consistently goes a bit cold during the prime line, causing SuperSlicer's insistently-inserted M109 to not immediately pass, causing a long pause after the prime line which defeats the purpose of the prime line by allowing the nozzle to deplete itself via oozing.

I've tested this on my V-Minion and its 0.4mm nozzle quite a bit, and it seems to produce similar results as the status quo.

This should work well with, but is otherwise independent of, my previous PR #54.