### PR TITLE
allow altering the ystart of the priming macros

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -27,6 +27,7 @@ variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
 variable_pause_print_park_in: "back"
 variable_macro_travel_speed: 150
+variable_prime_y_start: 10
 gcode:
   ECHO_RATOS_VARS
 
@@ -147,7 +148,8 @@ gcode:
 description: Prints a primeline, used internally, if configured, as part of the START_PRINT macro.
 gcode:
   SAVE_GCODE_STATE NAME=prime_line_state
-  {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+  {% set ratos = printer["gcode_macro RatOS"] %}
+  {% set speed = ratos.macro_travel_speed|float * 60 %}
   # Absolute positioning
   G90 
   # Absolute extrusion
@@ -157,15 +159,15 @@ gcode:
   # Lift 5 mm
   G1 Z5 F3000
   # Move to prime area
-  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + 10} F{speed}
+  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int} F{speed}
   # Get ready to prime
   G1 Z0.3 F3000
   # Reset extrusion distance
   G92 E0
   # Prime nozzle 
-  G1 Y{printer.toolhead.axis_minimum.y + 80} E16 F1200
+  G1 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int + 80} E16 F1200
   # Wipe
-  G1 Y{printer.toolhead.axis_minimum.y + 100} F{speed}
+  G1 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int + 100} F{speed}
   RESTORE_GCODE_STATE NAME=prime_line_state
 
 [gcode_macro PRIME_BLOB]
@@ -174,7 +176,8 @@ gcode:
   SAVE_GCODE_STATE NAME=prime_blob_state
   M117 Priming nozzle with prime blob..
   RESPOND MSG="Priming nozzle with prime blob.."
-  {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+  {% set ratos = printer["gcode_macro RatOS"] %}
+  {% set speed = ratos.macro_travel_speed|float * 60 %}
   # Absolute positioning
   G90 
   # Relative extrusion
@@ -182,7 +185,7 @@ gcode:
   # Lift 5 mm
   G1 Z5 F3000
   # move to blob position
-  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + 10} Z0.5 F{speed}
+  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int} Z0.5 F{speed}
   # Extrude a blob
   G1 F60 E20
   # 40% fan

--- a/macros.cfg
+++ b/macros.cfg
@@ -185,7 +185,7 @@ gcode:
   # Lift 5 mm
   G1 Z5 F3000
   # move to blob position
-  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int} Z0.5 F{speed}
+  G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int + 10} Z0.5 F{speed}
   # Extrude a blob
   G1 F60 E20
   # 40% fan
@@ -193,20 +193,20 @@ gcode:
   # Move the extruder up by 5mm while extruding, breaks away from blob
   G1 Z5 F100 E5  
   # Move to wipe position, but keep extruding so the wipe is attached to blob
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 25} E1 
+  G1 F200 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int + 25} E1 
   # Go down diagonally while extruding
   # Broken down in z moves under 2mm as a workaround for a tuning tower test.
   # The tuning tower command thinks a new print has been started when z moves over 2mm and aborts.
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 30} Z3.8 E0.5
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 35} Z2.6 E0.5
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 40} Z1.4 E0.5
-  G1 F200 Y{printer.toolhead.axis_minimum.y + 45} Z0.2 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int+ 30} Z3.8 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int+ 35} Z2.6 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int+ 40} Z1.4 E0.5
+  G1 F200 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int+ 45} Z0.2 E0.5
   # 0% fan
   M106 S0
   # small wipe line
-  G1 F200 Y{printer.toolhead.axis_minimum.y +50} Z0.2 E0.6 
+  G1 F200 Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int + 50} Z0.2 E0.6 
   # Break away wipe
-  G1 F{speed} Y{printer.toolhead.axis_minimum.y + 100}
+  G1 F{speed} Y{printer.toolhead.axis_minimum.y + ratos.prime_y_start|int + 100}
   RESTORE_GCODE_STATE NAME=prime_blob_state
 
   


### PR DESCRIPTION
When using a euclid probe the mount for docking the probe from euclidprobe.com (probably the one that most people use) is located at the 0,0 corner of the printer. When doing a prime line i found that would half pick up the probe.

This will allow a configurable y-start to the priming macros to avoid the probe dock.