### PR TITLE
Fix stowable probe calibrate

### DIFF
--- a/homing.cfg
+++ b/homing.cfg
@@ -6,62 +6,59 @@
 set_position_z: -5 # this is the minimum allowed Z which means the nozzle cannot move closer to the bed, for safety.
 axes: xyz
 gcode:
-	{% set x_homed = 'x' in printer.toolhead.homed_axes %}
-	{% set y_homed = 'y' in printer.toolhead.homed_axes %}
+    {% set x_homed = 'x' in printer.toolhead.homed_axes %}
+    {% set y_homed = 'y' in printer.toolhead.homed_axes %}
 	{% set safe_home_x = printer["gcode_macro RatOS"].safe_home_x %}
 	{% set safe_home_y = printer["gcode_macro RatOS"].safe_home_y %}
-	{% if safe_home_x is not defined or safe_home_x|lower == 'middle' %}
+	{% if safe_home_x is not defined or safe_home_x|lower = 'middle' %}
 		{% set safe_home_x = printer.toolhead.axis_maximum.x / 2 %}
 	{% endif %}
-	{% if safe_home_y is not defined or safe_home_y|lower == 'middle' %}
+	{% if safe_home_y is not defined or safe_home_y|lower = 'middle' %}
 		{% set safe_home_y = printer.toolhead.axis_maximum.y / 2 %}
 	{% endif %}
 	{% set z_hop = printer["gcode_macro RatOS"].homing_z_hop|float %}
 	{% set z_probe = printer["gcode_macro RatOS"].z_probe|lower %}
-	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
-	{% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
+  	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
 
-	M400                        # Wait for moves to finish
-	G90                         # Absolute positioning
-	G0 Z{z_hop} F{z_speed}      # Hop Z-Axis
+    M400                        # Wait for moves to finish
+    G90                         # Absolute positioning
+    G0 Z{z_hop} F1200           # Hop Z-Axis
 
-	{% if params.X is defined or params.Y is not defined and params.Z is not defined %}
+    {% if params.X is defined or params.Y is not defined and params.Z is not defined %}
 		{% if printer["gcode_macro RatOS"].homing|lower == 'endstops' %}
 			G28 X
 		{% elif printer["gcode_macro RatOS"].homing|lower == 'sensorless' %}
 			HOME_X_SENSORLESS
 		{% endif %}
-		{% set x_homed = True %}
-		G0 X{safe_home_x} F{speed}
-	{% endif %}
+        {% set x_homed = True %}
+    {% endif %}
 
-	{% if params.Y is defined or params.X is not defined and params.Z is not defined %}
+    {% if params.Y is defined or params.X is not defined and params.Z is not defined %}
 		{% if printer["gcode_macro RatOS"].homing|lower == 'endstops' %}
 			G28 Y
 		{% elif printer["gcode_macro RatOS"].homing|lower == 'sensorless' %}
 			HOME_Y_SENSORLESS
 		{% endif %}
-		{% set y_homed = True %}
-		G0 Y{safe_home_y} F{speed}
-	{% endif %}
+        {% set y_homed = True %}
+    {% endif %}
 
-	{% if params.Z is defined or params.Y is not defined and params.X is not defined %}
-		RESPOND MSG="Homing Z"
-		{% if x_homed == False or y_homed == False %}
-			M118 X and Y must be homed before homing Z
-		{% else %}
+    {% if params.Z is defined or params.Y is not defined and params.X is not defined %}
+        RESPOND MSG="Homing Z"
+        {% if x_homed == False or y_homed == False %}
+            M118 X and Y must be homed before homing Z
+        {% else %}
 			{% if z_probe == "stowable" %}
 				DEPLOY_PROBE
-				G0 X{safe_home_x} Y{safe_home_y} F{speed}
+            	G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				G28 Z
-				G0 Z{z_hop} F{z_speed}
+				G0 Z{z_hop} F1200
 				STOW_PROBE
 			{% else %}
 				G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				G28 Z
-				G0 Z{z_hop} F{z_speed} 
+				G0 Z{z_hop} F1200 
 			{% endif %}
-		{% endif %}
+        {% endif %}
 	{% endif %}
 
 
@@ -69,87 +66,82 @@ gcode:
 gcode:
   	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
 	{% set safe_home_x = printer["gcode_macro RatOS"].safe_home_x %}
-	{% if safe_home_x is not defined or safe_home_x|lower == 'middle' %}
+	{% if safe_home_x is not defined or safe_home_x|lower = 'middle' %}
 		{% set safe_home_x = printer.toolhead.axis_maximum.x / 2 %}
 	{% endif %}
-	M204 S1000            # Set homing acceleration (important!)
-	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer["gcode_macro RatOS"].sensorless_x_current}
-	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer["gcode_macro RatOS"].sensorless_x_current}
+    M204 S1000            # Set homing acceleration (important!)
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.6
+    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.6
 	G28 X
 	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.config["tmc2209 stepper_x"].run_current}
 	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.config["tmc2209 stepper_y"].run_current}
-	# Restore acceleration
-	M204 S{printer.configfile.config.printer.max_accel} 
+    # Restore acceleration
+    M204 S{printer.configfile.config.printer.max_accel} 
+	G0 X{safe_home_x} F{speed}
 
 [gcode_macro HOME_Y_SENSORLESS]
 gcode:
 	{% set safe_home_y = printer["gcode_macro RatOS"].safe_home_y %}
-	{% if safe_home_y is not defined or safe_home_y|lower == 'middle' %}
+	{% if safe_home_y is not defined or safe_home_y|lower = 'middle' %}
 		{% set safe_home_y = printer.toolhead.axis_maximum.y / 2 %}
 	{% endif %}
   	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
-	M204 S1000            # Set homing acceleration (important!)
-	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer["gcode_macro RatOS"].sensorless_y_current}
-	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer["gcode_macro RatOS"].sensorless_y_current}
+    M204 S1000            # Set homing acceleration (important!)
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.9
+    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.9
 	G28 Y
 	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.config["tmc2209 stepper_x"].run_current}
 	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.config["tmc2209 stepper_y"].run_current}
-	# Restore acceleration
-	M204 S{printer.configfile.config.printer.max_accel} 
+    # Restore acceleration
+    M204 S{printer.configfile.config.printer.max_accel} 
+	G0 Y{safe_home_y} F{speed}
 
 [gcode_macro MAYBE_HOME]
 description: Only home unhomed axis
-variable_is_kinematic_position_overriden: False
 gcode:
-  {% if printer["gcode_macro MAYBE_HOME"].is_kinematic_position_overriden|lower == 'true' %}
-    RESPOND MSG="SET_CENTER_KINEMATIC_POSITION has been abused. Homing all axes. Please refrain from using SET_CENTER_KINEMATIC_POSITION outside of debugging purposes."
-    G28
-    SET_GCODE_VARIABLE MACRO=MAYBE_HOME VARIABLE=is_kinematic_position_overriden VALUE=False
-  {% else %}
+  {% set axes = '' %}
+  {% set isHomed = true %}
+  {% set axesToHome = '' %}
+  {% if params.X is defined %}
+    {% set axes = axes ~ 'X ' %}
+    {% if 'x' not in printer.toolhead.homed_axes %}
+      {% set isHomed = false %}
+      {% set axesToHome = axesToHome ~ 'X ' %}
+    {% endif %}
+  {% endif %}
+  {% if params.Y is defined %}
+    {% set axes = axes ~ 'Y ' %}
+    {% if 'y' not in printer.toolhead.homed_axes %}
+      {% set isHomed = false %}
+      {% set axesToHome = axesToHome ~ 'Y ' %}
+    {% endif %}
+  {% endif %}
+  {% if params.Z is defined %}
+    {% set axes = axes ~ 'Z ' %}
+    {% if 'z' not in printer.toolhead.homed_axes %}
+      {% set isHomed = false %}
+      {% set axesToHome = axesToHome ~ 'Z ' %}
+    {% endif %}
+  {% endif %}
+  {% if params.X is not defined and params.Y is not defined and params.Z is not defined %}
     {% set axes = '' %}
-    {% set isHomed = true %}
-    {% set axesToHome = '' %}
-    {% if params.X is defined %}
-      {% set axes = axes ~ 'X ' %}
-      {% if 'x' not in printer.toolhead.homed_axes %}
-        {% set isHomed = false %}
-        {% set axesToHome = axesToHome ~ 'X ' %}
-      {% endif %}
+    {% if 'x' not in printer.toolhead.homed_axes %}
+      {% set isHomed = false %}
+      {% set axesToHome = axesToHome ~ 'X ' %}
     {% endif %}
-    {% if params.Y is defined %}
-      {% set axes = axes ~ 'Y ' %}
-      {% if 'y' not in printer.toolhead.homed_axes %}
-        {% set isHomed = false %}
-        {% set axesToHome = axesToHome ~ 'Y ' %}
-      {% endif %}
+    {% if 'y' not in printer.toolhead.homed_axes %}
+      {% set isHomed = false %}
+      {% set axesToHome = axesToHome ~ 'Y ' %}
     {% endif %}
-    {% if params.Z is defined %}
-      {% set axes = axes ~ 'Z ' %}
-      {% if 'z' not in printer.toolhead.homed_axes %}
-        {% set isHomed = false %}
-        {% set axesToHome = axesToHome ~ 'Z ' %}
-      {% endif %}
+    {% if 'z' not in printer.toolhead.homed_axes %}
+      {% set isHomed = false %}
+      {% set axesToHome = axesToHome ~ 'Z ' %}
     {% endif %}
-    {% if params.X is not defined and params.Y is not defined and params.Z is not defined %}
-      {% set axes = '' %}
-      {% if 'x' not in printer.toolhead.homed_axes %}
-        {% set isHomed = false %}
-        {% set axesToHome = axesToHome ~ 'X ' %}
-      {% endif %}
-      {% if 'y' not in printer.toolhead.homed_axes %}
-        {% set isHomed = false %}
-        {% set axesToHome = axesToHome ~ 'Y ' %}
-      {% endif %}
-      {% if 'z' not in printer.toolhead.homed_axes %}
-        {% set isHomed = false %}
-        {% set axesToHome = axesToHome ~ 'Z ' %}
-      {% endif %}
-    {% endif %}
-    {% if isHomed is false %}
-      M117 Homing {axesToHome}
-      RESPOND MSG="Homing {axesToHome}"
-      G28 {axesToHome}
-    {% else %}
-      RESPOND MSG="All requested axes already homed, skipping.."
-    {% endif %}
+  {% endif %}
+  {% if isHomed is false %}
+    M117 Homing {axesToHome}
+    RESPOND MSG="Homing {axesToHome}"
+    G28 {axesToHome}
+  {% else %}
+    RESPOND MSG="All requested axes already homed, skipping.."
   {% endif %}

--- a/homing.cfg
+++ b/homing.cfg
@@ -6,8 +6,8 @@
 set_position_z: -5 # this is the minimum allowed Z which means the nozzle cannot move closer to the bed, for safety.
 axes: xyz
 gcode:
-    {% set x_homed = 'x' in printer.toolhead.homed_axes %}
-    {% set y_homed = 'y' in printer.toolhead.homed_axes %}
+	{% set x_homed = 'x' in printer.toolhead.homed_axes %}
+	{% set y_homed = 'y' in printer.toolhead.homed_axes %}
 	{% set safe_home_x = printer["gcode_macro RatOS"].safe_home_x %}
 	{% set safe_home_y = printer["gcode_macro RatOS"].safe_home_y %}
 	{% if safe_home_x is not defined or safe_home_x|lower = 'middle' %}
@@ -18,38 +18,39 @@ gcode:
 	{% endif %}
 	{% set z_hop = printer["gcode_macro RatOS"].homing_z_hop|float %}
 	{% set z_probe = printer["gcode_macro RatOS"].z_probe|lower %}
-  	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+	{% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
 
-    M400                        # Wait for moves to finish
-    G90                         # Absolute positioning
-    G0 Z{z_hop} F1200           # Hop Z-Axis
+	M400                        # Wait for moves to finish
+	G90                         # Absolute positioning
+	G0 Z{z_hop} F{z_speed}      # Hop Z-Axis
 
-    {% if params.X is defined or params.Y is not defined and params.Z is not defined %}
+	{% if params.X is defined or params.Y is not defined and params.Z is not defined %}
 		{% if printer["gcode_macro RatOS"].homing|lower == 'endstops' %}
 			G28 X
 		{% elif printer["gcode_macro RatOS"].homing|lower == 'sensorless' %}
 			HOME_X_SENSORLESS
 		{% endif %}
-        {% set x_homed = True %}
-    {% endif %}
+		{% set x_homed = True %}
+	{% endif %}
 
-    {% if params.Y is defined or params.X is not defined and params.Z is not defined %}
+	{% if params.Y is defined or params.X is not defined and params.Z is not defined %}
 		{% if printer["gcode_macro RatOS"].homing|lower == 'endstops' %}
 			G28 Y
 		{% elif printer["gcode_macro RatOS"].homing|lower == 'sensorless' %}
 			HOME_Y_SENSORLESS
 		{% endif %}
-        {% set y_homed = True %}
-    {% endif %}
+		{% set y_homed = True %}
+	{% endif %}
 
-    {% if params.Z is defined or params.Y is not defined and params.X is not defined %}
-        RESPOND MSG="Homing Z"
-        {% if x_homed == False or y_homed == False %}
-            M118 X and Y must be homed before homing Z
-        {% else %}
+	{% if params.Z is defined or params.Y is not defined and params.X is not defined %}
+		RESPOND MSG="Homing Z"
+		{% if x_homed == False or y_homed == False %}
+			M118 X and Y must be homed before homing Z
+		{% else %}
 			{% if z_probe == "stowable" %}
 				DEPLOY_PROBE
-            	G0 X{safe_home_x} Y{safe_home_y} F{speed}
+				G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				G28 Z
 				G0 Z{z_hop} F1200
 				STOW_PROBE
@@ -58,7 +59,7 @@ gcode:
 				G28 Z
 				G0 Z{z_hop} F1200 
 			{% endif %}
-        {% endif %}
+		{% endif %}
 	{% endif %}
 
 
@@ -69,14 +70,14 @@ gcode:
 	{% if safe_home_x is not defined or safe_home_x|lower = 'middle' %}
 		{% set safe_home_x = printer.toolhead.axis_maximum.x / 2 %}
 	{% endif %}
-    M204 S1000            # Set homing acceleration (important!)
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.6
-    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.6
+	M204 S1000            # Set homing acceleration (important!)
+	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer["gcode_macro RatOS"].sensorless_x_current}
+	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer["gcode_macro RatOS"].sensorless_x_current}
 	G28 X
 	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.config["tmc2209 stepper_x"].run_current}
 	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.config["tmc2209 stepper_y"].run_current}
-    # Restore acceleration
-    M204 S{printer.configfile.config.printer.max_accel} 
+	# Restore acceleration
+	M204 S{printer.configfile.config.printer.max_accel} 
 	G0 X{safe_home_x} F{speed}
 
 [gcode_macro HOME_Y_SENSORLESS]
@@ -86,62 +87,62 @@ gcode:
 		{% set safe_home_y = printer.toolhead.axis_maximum.y / 2 %}
 	{% endif %}
   	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
-    M204 S1000            # Set homing acceleration (important!)
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.9
-    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.9
+	M204 S1000            # Set homing acceleration (important!)
+	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer["gcode_macro RatOS"].sensorless_y_current}
+	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer["gcode_macro RatOS"].sensorless_y_current}
 	G28 Y
 	SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.config["tmc2209 stepper_x"].run_current}
 	SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.config["tmc2209 stepper_y"].run_current}
-    # Restore acceleration
-    M204 S{printer.configfile.config.printer.max_accel} 
+	# Restore acceleration
+	M204 S{printer.configfile.config.printer.max_accel} 
 	G0 Y{safe_home_y} F{speed}
 
 [gcode_macro MAYBE_HOME]
 description: Only home unhomed axis
 gcode:
-  {% set axes = '' %}
-  {% set isHomed = true %}
-  {% set axesToHome = '' %}
-  {% if params.X is defined %}
-    {% set axes = axes ~ 'X ' %}
-    {% if 'x' not in printer.toolhead.homed_axes %}
-      {% set isHomed = false %}
-      {% set axesToHome = axesToHome ~ 'X ' %}
-    {% endif %}
-  {% endif %}
-  {% if params.Y is defined %}
-    {% set axes = axes ~ 'Y ' %}
-    {% if 'y' not in printer.toolhead.homed_axes %}
-      {% set isHomed = false %}
-      {% set axesToHome = axesToHome ~ 'Y ' %}
-    {% endif %}
-  {% endif %}
-  {% if params.Z is defined %}
-    {% set axes = axes ~ 'Z ' %}
-    {% if 'z' not in printer.toolhead.homed_axes %}
-      {% set isHomed = false %}
-      {% set axesToHome = axesToHome ~ 'Z ' %}
-    {% endif %}
-  {% endif %}
-  {% if params.X is not defined and params.Y is not defined and params.Z is not defined %}
-    {% set axes = '' %}
-    {% if 'x' not in printer.toolhead.homed_axes %}
-      {% set isHomed = false %}
-      {% set axesToHome = axesToHome ~ 'X ' %}
-    {% endif %}
-    {% if 'y' not in printer.toolhead.homed_axes %}
-      {% set isHomed = false %}
-      {% set axesToHome = axesToHome ~ 'Y ' %}
-    {% endif %}
-    {% if 'z' not in printer.toolhead.homed_axes %}
-      {% set isHomed = false %}
-      {% set axesToHome = axesToHome ~ 'Z ' %}
-    {% endif %}
-  {% endif %}
-  {% if isHomed is false %}
-    M117 Homing {axesToHome}
-    RESPOND MSG="Homing {axesToHome}"
-    G28 {axesToHome}
-  {% else %}
-    RESPOND MSG="All requested axes already homed, skipping.."
-  {% endif %}
+	{% set axes = '' %}
+	{% set isHomed = true %}
+	{% set axesToHome = '' %}
+	{% if params.X is defined %}
+		{% set axes = axes ~ 'X ' %}
+		{% if 'x' not in printer.toolhead.homed_axes %}
+			{% set isHomed = false %}
+			{% set axesToHome = axesToHome ~ 'X ' %}
+		{% endif %}
+	{% endif %}
+	{% if params.Y is defined %}
+		{% set axes = axes ~ 'Y ' %}
+		{% if 'y' not in printer.toolhead.homed_axes %}
+			{% set isHomed = false %}
+			{% set axesToHome = axesToHome ~ 'Y ' %}
+		{% endif %}
+	{% endif %}
+	{% if params.Z is defined %}
+		{% set axes = axes ~ 'Z ' %}
+		{% if 'z' not in printer.toolhead.homed_axes %}
+			{% set isHomed = false %}
+			{% set axesToHome = axesToHome ~ 'Z ' %}
+		{% endif %}
+	{% endif %}
+	{% if params.X is not defined and params.Y is not defined and params.Z is not defined %}
+		{% set axes = '' %}
+		{% if 'x' not in printer.toolhead.homed_axes %}
+			{% set isHomed = false %}
+			{% set axesToHome = axesToHome ~ 'X ' %}
+		{% endif %}
+		{% if 'y' not in printer.toolhead.homed_axes %}
+			{% set isHomed = false %}
+			{% set axesToHome = axesToHome ~ 'Y ' %}
+		{% endif %}
+		{% if 'z' not in printer.toolhead.homed_axes %}
+			{% set isHomed = false %}
+			{% set axesToHome = axesToHome ~ 'Z ' %}
+		{% endif %}
+	{% endif %}
+	{% if isHomed is false %}
+		M117 Homing {axesToHome}
+		RESPOND MSG="Homing {axesToHome}"
+		G28 {axesToHome}
+	{% else %}
+		RESPOND MSG="All requested axes already homed, skipping.."
+	{% endif %}

--- a/macros.cfg
+++ b/macros.cfg
@@ -27,8 +27,6 @@ variable_start_print_park_z_height: 50
 variable_end_print_park_in: "back"
 variable_pause_print_park_in: "back"
 variable_macro_travel_speed: 150
-variable_macro_z_speed: 10
-variable_end_print_park_z_hop: 20
 # Possible values: 'sensorless' or 'endstops'.
 variable_homing: "endstops"
 variable_homing_z_hop: 15

--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -28,7 +28,6 @@
 ### BASE SETUP
 #############################################################################################################
 [include config/printers/v-core-3/v-core-3.cfg]
-[include config/homing.cfg]
 [include config/macros.cfg]
 [include config/shell-macros.cfg]
 [include config/printers/v-core-3/macros.cfg]
@@ -62,17 +61,13 @@
 ### Pick your probe and endstops
 #############################################################################################################
 # BL Touch
-#[include config/z-probe/bltouch.cfg]
+# [include config/z-probe/bltouch.cfg]
 
 # Inductive/Capacitive probe
 [include config/z-probe/probe.cfg]
 
 # Euclid probe (please read the RatOS documentation for instructions)
 #[include config/z-probe/euclid.cfg]
-
-# Klicky probe (please read the RatOS documentation for instructions)
-#[include config/z-probe/klicky/klicky.cfg]
-#[include config/z-probe/klicky/unklicky.cfg]
 
 # Physical endstops
 [include config/printers/v-core-3/physical-endstops.cfg]
@@ -193,9 +188,9 @@ rotation_distance: 4 # 4 for TR8*4 lead screws
 dir_pin: !z2_dir_pin # Add ! in front of pin name to reverse Z2 direction
 rotation_distance: 4 # 4 for TR8*4 lead screws
 
-# BLTouch configuration
-#[bltouch]
-#z_offset: 0.0 # Adjust this to fit your setup
+# Z Probe configuration
+# [bltouch]
+# z_offset: 0.0 # Adjust this to fit your setup
 
 # Inductive probe configuration
 [probe]

--- a/templates/v-core-pro-printer.template.cfg
+++ b/templates/v-core-pro-printer.template.cfg
@@ -27,7 +27,6 @@
 ### BASE SETUP
 #############################################################################################################
 [include config/printers/v-core-pro/v-core-pro.cfg]
-[include config/homing.cfg]
 [include config/macros.cfg]
 [include config/shell-macros.cfg]
 [include config/printers/v-core-pro/macros.cfg]

--- a/templates/v-minion-printer.template.cfg
+++ b/templates/v-minion-printer.template.cfg
@@ -32,7 +32,6 @@
 ### BASE SETUP
 #############################################################################################################
 [include config/printers/v-minion/v-minion.cfg]
-[include config/homing.cfg]
 [include config/macros.cfg]
 [include config/shell-macros.cfg]
 [include config/printers/v-minion/macros.cfg]

--- a/z-probe/euclid.cfg
+++ b/z-probe/euclid.cfg
@@ -3,50 +3,12 @@
 # sections into your printer.cfg and change it there.
 
 [include stowable-probe.cfg]
-#  __________________________________________________________________________
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                * Probe Ready Position                  |
-#  |                                  XMax/2 YMax/2``                       |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  | * Dock Exit   * Dock Preflight                                         | 
-#  |   X0 Y60        X30 Y60                                                |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |   X0 Y0        X30 Y0                                                  |
-#  | * Dock       * Dock Side                                               |
-#  |________________________________________________________________________| 
-[gcode_macro RatOS]
-variable_stowable_probe_position_preflight: [ 30, 60 ]
-variable_stowable_probe_position_side:      [  30, 0 ]
-variable_stowable_probe_position_dock:      [   0, 0 ]
-# exit/re-entry staging
-variable_stowable_probe_position_exit:      [   0, 60 ]
-# 300 * 60
-variable_stowable_probe_batch_mode_enabled: False
-variable_stowable_probe_state: None
-variable_homing_z_hop: 25
 
 [probe]
 pin: ^probe_pin
 x_offset: -27.942
 y_offset: -16.75
+z_offset: 0
 speed: 15
 lift_speed: 15
 samples: 1                   ; number of probes to perform per sample

--- a/z-probe/stowable-probe.cfg
+++ b/z-probe/stowable-probe.cfg
@@ -15,30 +15,32 @@
 #  |                                                                        |
 #  |                                                                        |
 #  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
-#  |                                                                        |
 #  |                                * Probe Ready Position                  |
 #  |                                  XMax/2 YMax/2``                       |
 #  |                                                                        |
 #  |                                                                        |
-#  |                                                                        |
-#  | * Dock Exit   * Dock Preflight                                         | 
-#  |   X0 Y60        X30 Y60                                                |
-#  |                                                                        |
+#  | * Dock Re-entry staging  position                                      |
+#  |   X0 Y70                                                               |
 #  |                                                                        |
 #  |                                                                        |
+#  | * Dock Exit Position                                                   | 
+#  |   X0 Y40                                                               |
 #  |                                                                        |
 #  |                                                                        |
-#  |   X0 Y0        X30 Y0                                                  |
-#  | * Dock       * Dock Side                                               |
+#  |                                                                        |
+#  |                                                                        |
+#  |                                                                        |
+#  |   X0 Y0    X30 Y0       X100 Y0                                        |
+#  | * Dock   * Dock Side  * Dock Preflight                                 |
 #  |________________________________________________________________________| 
 variable_z_probe: "stowable"
-variable_stowable_probe_position_preflight: [ 30, 60 ]
+variable_stowable_probe_position_preflight: [ 100, 0 ]
 variable_stowable_probe_position_side:      [  30, 0 ]
 variable_stowable_probe_position_dock:      [   0, 0 ]
 # exit/re-entry staging
-variable_stowable_probe_position_exit:      [   0, 60 ]
+variable_stowable_probe_position_exit:      [   0, 40 ]
+# how much space to put between the bed and nozzle for homing
+variable_z_hop: 20
 # 300 * 60
 variable_stowable_probe_batch_mode_enabled: False
 variable_stowable_probe_state: None
@@ -61,9 +63,9 @@ gcode:
 [gcode_macro ASSERT_PROBE_DEPLOYED]
 description: error if probe not deployed
 gcode:
-    ; wait for moves to finish, then pause 0.1s for detection
+    ; wait for moves to finish, then pause 0.25s for detection
     M400
-    G4 P100
+    G4 P250
 
     QUERY_PROBE
     _ASSERT_PROBE_STATE MUST_BE=deployed
@@ -71,9 +73,9 @@ gcode:
 [gcode_macro ASSERT_PROBE_STOWED]
 description: error if probe not stowed
 gcode:
-    ; wait for moves to finish, then pause 0.1s for detection
+    ; wait for moves to finish, then pause 0.25s for detection
     M400
-    G4 P100
+    G4 P250
 
     QUERY_PROBE
     _ASSERT_PROBE_STATE MUST_BE=stowed
@@ -96,8 +98,7 @@ gcode:
 description: Deploy a stowable probe
 gcode:
     {% set RatOS = printer["gcode_macro RatOS"] %}
-    {% set speed = RatOS.macro_travel_speed * 60 %}
-    {% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
+    {$ set speed = RatOS.macro_travel_speed * 60}
 
     {% if RatOS.stowable_probe_batch_mode_enabled and RatOS.stowable_probe_state == "deployed" %}
         RESPOND TYPE=command MSG="Probe batch mode enabled: already deployed"
@@ -110,7 +111,7 @@ gcode:
         G90
 
         ; set approach elevation to clear probe over bed on fixed gantry machine
-        G0 Z{ RatOS.homing_z_hop } F{z_speed}
+        G0 Z{ RatOS.stowable_probe_bed_clearance } F500
 
         ; move the carraige to safe position to start probe pickup
         G0 X{ RatOS.stowable_probe_position_preflight[0] } Y{ RatOS.stowable_probe_position_preflight[1] } F{ speed }
@@ -118,22 +119,25 @@ gcode:
         ;  move to the side of the dock
         G0 X{ RatOS.stowable_probe_position_side[0] } Y{ RatOS.stowable_probe_position_side[1] } F{ speed }
 
-        ;  move sideways over the dock to pick up probe
-        G0 X{ RatOS.stowable_probe_position_dock[0] } Y{ RatOS.stowable_probe_position_dock[1] } F{ speed }
+        ; wait 1/4 second
+        M400
+        G4 P250
 
-        ; move out of the dock in a straight line
-        G0 X{ RatOS.stowable_probe_position_exit[0] } Y{ RatOS.stowable_probe_position_exit[1] } F{ speed }
+        ;  move sideways over the dock to pick up probe
+        G0 X{ RatOS.stowable_probe_position_dock[0] } Y{ RatOS.stowable_probe_position_dock[1] } F1500
 
         ; confirm deploy was successful
         ASSERT_PROBE_DEPLOYED
 
+        ; move out of the dock in a straight line
+        G0 X{ RatOS.stowable_probe_position_exit[0] } Y{ RatOS.stowable_probe_position_exit[1] } F{ speed }
     {% endif %}
 
 [gcode_macro STOW_PROBE]
 description: Stow a stowable probe
 gcode:
     {% set RatOS = printer["gcode_macro RatOS"] %}
-    {% set speed = RatOS.macro_travel_speed * 60 %}
+    {$ set speed = RatOS.macro_travel_speed * 60}
 
     {% if RatOS.stowable_probe_batch_mode_enabled %}
         RESPOND TYPE=command MSG="Probe batch mode enabled: not stowing"
@@ -146,19 +150,20 @@ gcode:
         G90
 
         ; set approach elevation for fixed gantry system to clear probe over bed
-        G0 Z{ RatOS.homing_z_hop } F3000
+        G0 Z{ RatOS.stowable_probe_bed_clearance } F3000
 
         ; move to the exit/re-entry staging position
         G0 X{ RatOS.stowable_probe_position_exit[0] } Y{ RatOS.stowable_probe_position_exit[1] } F{ speed }
 
-        ; move into dock
-        G0 X{ RatOS.stowable_probe_position_dock[0] } Y{ RatOS.stowable_probe_position_dock[1] } F{ speed }
+        ; slowly move into dock
+        G0 X{ RatOS.stowable_probe_position_dock[0] } Y{ RatOS.stowable_probe_position_dock[1] } F3000
+
+        ; wait for moves to finish, pause to force 90deg travel swipe
+        M400
+        G4 P250
 
         ; quick swipe off
         G0 X{ RatOS.stowable_probe_position_side[0] } Y{ RatOS.stowable_probe_position_side[1] } F{ speed }
-
-        ; move the carraige to safe position
-        G0 X{ RatOS.stowable_probe_position_preflight[0] } Y{ RatOS.stowable_probe_position_preflight[1] } F{ speed }
 
         ; confirm stowing was successful
         ASSERT_PROBE_STOWED
@@ -168,19 +173,24 @@ gcode:
 [gcode_macro BED_MESH_CALIBRATE]
 rename_existing: BED_MESH_CALIBRATE_ORIG
 gcode:
-    {% set args = [] %}
-    {% for p in params %}
-        {% set tmp = args.append('%s=%s' % (p, params[p])) %}
-    {% endfor %}
-    DEPLOY_PROBE
-    BED_MESH_CALIBRATE_ORIG {args|join(' ')} 
+	DEPLOY_PROBE
+	BED_MESH_CALIBRATE_ORIG
 	STOW_PROBE
+
+# Macro to perform a modified z_tilt by wrapping it in DEPLOY_PROBE/STOW_PROBE macros
+[gcode_macro Z_TILT_ADJUST]
+rename_existing: Z_TILT_ADJUST_ORIG
+gcode:
+    DEPLOY_PROBE
+    Z_TILT_ADJUST_ORIG
+    STOW_PROBE
+
 
 [gcode_macro PROBE_CALIBRATE]
 rename_existing: PROBE_CALIBRATE_ORIG
 gcode:
     {% set RatOS = printer["gcode_macro RatOS"] %}  # this is the contents of line 144
-    {% set speed = RatOS.macro_travel_speed * 60 %}
+    {$ set speed = RatOS.macro_travel_speed * 60}
     DEPLOY_PROBE
     G90
     G0 X{ printer.toolhead.axis_maximum.x/2 } Y{ printer.toolhead.axis_maximum.y/2 } F{ speed }

--- a/z-probe/stowable-probe.cfg
+++ b/z-probe/stowable-probe.cfg
@@ -185,7 +185,6 @@ gcode:
     Z_TILT_ADJUST_ORIG
     STOW_PROBE
 
-
 [gcode_macro PROBE_CALIBRATE]
 rename_existing: PROBE_CALIBRATE_ORIG
 gcode:
@@ -195,7 +194,9 @@ gcode:
     G90
     G0 X{ printer.toolhead.axis_maximum.x/2 } Y{ printer.toolhead.axis_maximum.y/2 } F{ speed }
     PROBE_CALIBRATE_ORIG
-    STOW_PROBE
+    M118 moving the toolhead 20 mm from the bed
+    TESTZ Z=20
+    M118 remove manually the probe and continue calibration
 
 [gcode_macro PROBE_ACCURACY]
 rename_existing: PROBE_ACCURACY_ORIG

--- a/z-probe/stowable-probe.cfg
+++ b/z-probe/stowable-probe.cfg
@@ -201,5 +201,14 @@ gcode:
 [gcode_macro PROBE_ACCURACY]
 rename_existing: PROBE_ACCURACY_ORIG
 gcode:
-    ASSERT_PROBE_DEPLOYED
-    PROBE_ACCURACY_ORIG
+    {% set RatOS = printer["gcode_macro RatOS"] %}
+    SAVE_GCODE_STATE NAME=PROBE_ACCURACY
+    DEPLOY_PROBE
+    ASSERT_PROBE_DEPLOYED    
+    RESTORE_GCODE_STATE NAME=PROBE_ACCURACY MOVE=1
+    PROBE_ACCURACY_ORIG {% for p in params
+            %}{'%s=%s ' % (p, params[p])}{%
+           endfor %}
+    STOW_PROBE
+    RESTORE_GCODE_STATE NAME=PROBE_ACCURACY MOVE=1
+


### PR DESCRIPTION
`gcode_macro PROBE_CALIBRATE
`
- Original docked probe while in `TESTZ` mode meaning nozzle was not in correct place
- Fixed version doesn't automatically dock. User needs to remove probe and nozzle stays in the correct location

`gcode_macro PROBE_ACCURACY`

- Original didn't auto pick up probe, fixed version does
- Original didn't auto dock probe, fixed version does
- Fixed version stores position and then returns to the location to run the accuracy test after picking up probe
- Fixed version returns to stored position after docking probe 