### PR TITLE
output extruder being heated

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -345,6 +345,8 @@ gcode:
   # Run the customizable "PARK" macro
   _START_PRINT_PARK
   # Wait for extruder to heat up
+  M117 Heating Extruder...
+  RESPOND MSG="Heating Extruder..."
   M109 S{params.EXTRUDER_TEMP|default(printer.extruder.target, true) }
   # Run the customizable "AFTER_HEATING_EXTRUDER" macro.
   _START_PRINT_AFTER_HEATING_EXTRUDER


### PR DESCRIPTION
There is a message about pre-heating the hotend, but nothing is output when it is being heated to final temperature. This pull request fixes that, and tells the user when the hotend is being heated.