### PR TITLE
Ensure valid moonraker conf

### DIFF
--- a/old-moonraker.conf
+++ b/old-moonraker.conf
@@ -1,9 +1,12 @@
 [server]
 host: 0.0.0.0
 port: 7125
+enable_debug_logging: False
 max_upload_size: 1024
 
 [file_manager]
+config_path: ~/klipper_config
+log_path: ~/klipper_logs
 enable_object_processing: False
 
 [update_manager]

--- a/scripts/ratos-update.sh
+++ b/scripts/ratos-update.sh
@@ -46,6 +46,17 @@ fix_klipperscreen_permissions()
   chown -R pi /home/pi/KlipperScreen
 }
 
+validate_moonraker_config()
+{
+  echo "Ensuring valid moonraker config.."
+  install_version=$(/home/pi/moonraker-env/bin/python -mlmdb -e /home/pi/.moonraker_database/ -d moonraker get validate_install)
+  if [ "$install_version" = "'validate_install': missing" ]; then
+    # Temporarily replace with old config
+    echo "Installing old moonraker config.."
+    cp /home/pi/klipper_config/config/old-moonraker.conf /home/pi/klipper_config/config/moonraker.conf
+  fi
+}
+
 # Run update symlinks
 update_symlinks
 ensure_ownership
@@ -55,4 +66,5 @@ ensure_moonraker_policiykit_rules
 [ $? -eq 1 ] && echo "Policykit rules have changed. You will have to manually restart moonraker. Power cycling the raspberry pi will also do the trick."
 fix_klipperscreen_forcepush
 fix_klipperscreen_permissions
+validate_moonraker_config
 restart_klipper


### PR DESCRIPTION
This PR implements a workaround to ensure compatibility with the new Moonraker config changes and the automations around it. To sum up, this is the what we decided to do as suggested by arksine:

 - Remove deprecated options
 - When updating and moonraker hasn't run it's install validation stuff, readd the config options to the ratos moonraker.conf include, making the ratos repo dirty.
 - When moonraker runs it's install validation stuff, it will do all the fixes and remove the config options from the ratos moonraker.conf and the ratos repo would be pristine.
 
 See: Arksine/moonraker/pull/491