### PR TITLE
Correct direction change in prime blob when backwards

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -222,9 +222,9 @@ gcode:
   # 0% fan
   M106 S0
   # small wipe line
-  G1 F200 Y{y_start + 50} Z0.2 E0.6 
+  G1 F200 Y{y_start + (50 * y_factor)} Z0.2 E0.6 
   # Break away wipe
-  G1 F{speed} Y{y_start + 100}
+  G1 F{speed} Y{y_start + (100 * y_factor)}
   RESTORE_GCODE_STATE NAME=prime_blob_state
 
   


### PR DESCRIPTION
Updates the macro to be consistent when the prime blob direction is backwards. Before, it changed direction mid blob (missing y_factor), now it works the same way when going forwards or backwards.