### PR TITLE
Fix V-Minion X and Y stepper directions

### DIFF
--- a/templates/v-minion-printer.template.cfg
+++ b/templates/v-minion-printer.template.cfg
@@ -212,14 +212,14 @@ variable_macro_travel_speed: 300
 #############################################################################################################
 
 [stepper_x]
-dir_pin: !x_dir_pin # Add ! in front of pin name to reverse X stepper direction
+dir_pin: x_dir_pin # Add ! in front of pin name to reverse X stepper direction
 rotation_distance: 40 # 40 for 20 tooth 2GT pulleys, 32 for 16 tooth 2GT pulleys
 position_endstop: 0 # Adjust this to your setup
 position_min: 0 # Adjust this to your setup
 position_max: 180 # Adjust this to your setup
 
 [stepper_y]
-dir_pin: y_dir_pin # Add ! in front of pin name to reverse Y stepper direction
+dir_pin: !y_dir_pin # Add ! in front of pin name to reverse Y stepper direction
 rotation_distance: 40 # 40 for 20 tooth 2GT pulleys, 32 for 16 tooth 2GT pulleys
 position_endstop: 0 # Adjust this to your setup
 position_min: 0 # Adjust this to your setup


### PR DESCRIPTION
Following the connection guide to the letter or color in this case for the motor cables will result in the V-Minion having X and Y reversed. This fixes it.