### PR TITLE
Filename correction for 4 pin fans

### DIFF
--- a/templates/v-core-3-printer.template.cfg
+++ b/templates/v-core-3-printer.template.cfg
@@ -154,8 +154,8 @@
 #[include RatOS/4pin-fans/part-cooling-fan-100hz.cfg]
 
 # Hotend / Toolhead cooling
-#[include RatOS/4pin-fans/toolhead-cooling-fan-25khz.cfg]
-#[include RatOS/4pin-fans/toolhead-cooling-fan-100hz.cfg]
+#[include RatOS/4pin-fans/toolhead-fan-25khz.cfg]
+#[include RatOS/4pin-fans/toolhead-fan-100hz.cfg]
 
 # Control board cooling
 #[include RatOS/4pin-fans/controller-fan-25khz.cfg]


### PR DESCRIPTION
toolhead-cooling-fan config files do not exist, they are named toolhead-fan-xxxxx.cfg