### PR TITLE
Change X-Endstop from PB6 to PC13

### DIFF
--- a/boards/btt-ebb36-10/toolboard-config.cfg
+++ b/boards/btt-ebb36-10/toolboard-config.cfg
@@ -5,7 +5,7 @@
 [board_pins btt-ebb36-10]
 mcu: toolboard
 aliases:
-	x_endstop_pin=PB6,
+	x_endstop_pin=PC13,
 	e_step_pin=PA9, e_dir_pin=PA8, e_enable_pin=PA10, e_uart_pin=PA13, e_diag_pin=null, e_heater_pin=PB1, e_sensor_pin=PA0,
 	thermocouple_cs=PA15, thermocouple_miso=PB4, thermocouple_mosi=PB5, thermocouple_clk=PB3,
 	# accel


### PR DESCRIPTION
`The` X-Endstop on Board Hardware Rev. 1.0 is on PC13 instead of PB6 see: 
![image](https://user-images.githubusercontent.com/10465613/224401969-7dd540ce-af2f-4ed8-aa63-de7457fef883.png)
