### PR TITLE
Fix the INSTALL_PRUSA_MK3 macro

### DIFF
--- a/printers/initial-setup.cfg
+++ b/printers/initial-setup.cfg
@@ -100,7 +100,7 @@ gcode:
   M118 Prusa MINI config installed. Please open printer.cfg!
   RESTART
 
-[gcode_macro INSTALL_PRUSA_MK3S]
+[gcode_macro INSTALL_PRUSA_MK3]
 gcode:
   RUN_SHELL_COMMAND CMD=copy_prusa_mk3s
   M118 Prusa MK3S config installed. Please open printer.cfg!


### PR DESCRIPTION
Just rename the macro INSTALL_PRUSA_MK3S to INSTALL_PRUSA_MK3 in order to fix the issue with the initial printer installation.