### PR TITLE
Fix compiled file name on compile.sh script for einsy board

### DIFF
--- a/boards/prusa-buddy/compile.sh
+++ b/boards/prusa-buddy/compile.sh
@@ -16,7 +16,7 @@ then
     mkdir /home/pi/printer_data/config/firmware_binaries
     chown pi:pi /home/pi/printer_data/config/firmware_binaries
 fi
-cp -f /home/pi/klipper/out/klipper.bin /home/pi/printer_data/config/firmware_binaries/firmware-prusa-buddy.bin
+cp -f /home/pi/klipper/out/klipper.elf.hex /home/pi/printer_data/config/firmware_binaries/firmware-prusa-buddy.bin
 chown pi:pi /home/pi/printer_data/config/firmware_binaries/firmware-prusa-buddy.bin
 
 # Reset ownership


### PR DESCRIPTION
The compile script was referencing to klipper.bin instead of klipper.elf.hex, because of that was not able to copy to the correct path and the configurator was not able to flash it automatically, even the flash script was working because when the flash command is executed will look for the klipper.elf.hex on the out folder. 
Whit this change the configurator got solved