### PR TITLE
feat: add 4 pin fan definitions for manta m8p

### DIFF
--- a/boards/btt-manta-m8p/config.cfg
+++ b/boards/btt-manta-m8p/config.cfg
@@ -18,10 +18,17 @@ aliases:
 # auto leveling
   bltouch_sensor_pin=PB2,  bltouch_control_pin=PB1,
   probe_pin=PB2,
-# fans
+# 2 pin fans
   fan_part_cooling_pin=PE6,
   fan_toolhead_cooling_pin=PE0,
   fan_controller_board_pin=PC12,
+# 4 pin fans
+  4p_fan_part_cooling_pin=PE14,
+  4p_fan_part_cooling_tach_pin=PC13,
+  4p_toolhead_cooling_pin=PB8,
+  4p_toolhead_cooling_tach_pin=PC14,
+  4p_controller_board_pin=PB9,
+  4p_controller_board_tach_pin=PC15,
 # Bed heater
   heater_bed_heating_pin=PB7,
   heater_bed_sensor_pin=PA0 ,

--- a/boards/btt-manta-m8p/config.cfg
+++ b/boards/btt-manta-m8p/config.cfg
@@ -23,7 +23,7 @@ aliases:
   fan_toolhead_cooling_pin=PE0,
   fan_controller_board_pin=PC12,
 # 4 pin fans
-  4p_fan_part_cooling_pin=PE14,
+  4p_fan_part_cooling_pin=PE4,
   4p_fan_part_cooling_tach_pin=PC13,
   4p_toolhead_cooling_pin=PB8,
   4p_toolhead_cooling_tach_pin=PC14,


### PR DESCRIPTION
I noticed while trying to help in https://discord.com/channels/582187371529764864/1086663477709508648 that the 4 pin definitions are missing for the manta m8p