### PR TITLE
Make bed mesh clear only predefined config

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -427,11 +427,12 @@ gcode:
 [gcode_macro _START_PRINT_BED_MESH]
 gcode:
   {% set default_profile = printer["gcode_macro RatOS"].bed_mesh_profile|default('ratos') %}
-  BED_MESH_CLEAR
   {% if printer["gcode_macro RatOS"].calibrate_bed_mesh|lower == 'true' %}
+    BED_MESH_CLEAR
     BED_MESH_CALIBRATE PROFILE={default_profile}
     BED_MESH_PROFILE LOAD={default_profile}
   {% elif printer["gcode_macro RatOS"].bed_mesh_profile is defined %}
+    BED_MESH_CLEAR
     BED_MESH_PROFILE LOAD={printer["gcode_macro RatOS"].bed_mesh_profile}
   {% endif %}
 


### PR DESCRIPTION
Bed mesh is being cleared even though the bed mesh has been manually selected from the mainsail. 
And with `calibrate_bed` set to `false` and without `bed_mesh_profile` config being set, it always removes the bed mesh.