### PR TITLE
Perform the final approach to prime blob location horizontally

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -212,11 +212,13 @@ gcode:
   M83
   # Lift to start print Z height
   G0 Z{z} F{z_speed}
-  # move to blob position along the edge of the bed
+  # move close to blob position along the edge of the bed
   G1 X{x_start} F{speed}
-  G1 Y{y_start} F{speed}
-  # Lower to blob height
+  G1 Y{y_start + (15 * y_factor)} F{speed}
+  # Lower to blob extrusion height
   G1 Z0.5 F{z_speed}
+  # Move to final position horizontally
+  G1 Y{y_start} F{speed}
   # Extrude a blob
   G1 F60 E20
   # 40% fan


### PR DESCRIPTION
If a previous prime blob hasn't been removed and the print head is lowered vertically on top of it, the nozzle will crash on the cold plastic and twist the whole toolhead. This PR modifies the movement path so that the head is first lowered at location (x, y+15) and then driven horizontally to the final location. This causes the previous prime blob to be harmlessly popped off.