### PR TITLE
Native adaptive meshing and priming

### DIFF
--- a/homing.cfg
+++ b/homing.cfg
@@ -80,7 +80,6 @@ gcode:
 	# Reset stowable probe stop on error state
 	SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=stowable_probe_stop_on_error VALUE={prev_stop_on_error}
 
-
 [gcode_macro HOME_X_SENSORLESS]
 gcode:
   	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}

--- a/macros.cfg
+++ b/macros.cfg
@@ -53,6 +53,7 @@ variable_stowable_probe_stop_on_error: False
 variable_driver_type_x: "tmc2209"
 variable_driver_type_y: "tmc2209"
 variable_adaptive_mesh: False
+variable_probe_for_priming_result: None
 gcode:
   ECHO_RATOS_VARS
 
@@ -619,6 +620,19 @@ gcode:
       {% set y_start = printer["gcode_macro RatOS"].nozzle_prime_start_y|float %}
     {% endif %}
     {% set z = printer.configfile.settings.bed_mesh.horizontal_move_z|float %}
+    # get bed mesh config object
+    {% set mesh_config = printer.configfile.config.bed_mesh %}
+
+    # get configured bed mesh area
+    {% set min_x = mesh_config.mesh_min.split(",")[0]|float %}
+    {% set min_y = mesh_config.mesh_min.split(",")[1]|float %}
+    {% set max_x = mesh_config.mesh_max.split(",")[0]|float %}
+    {% set max_y = mesh_config.mesh_max.split(",")[1]|float %}
+
+    # make sure mesh coordinates lie within the configured mesh area
+    {% set x_start = [[x_start, max_x]|min, min_x]|max %}
+    {% set y_start = [[y_start, max_y]|min, min_y]|max %}
+
     # Absolute positioning
     G90 
     # Relative extrusion
@@ -630,7 +644,7 @@ gcode:
     PROBE_CURRENT_POSITION
     SAVE_PROBE_RESULT VARIABLE=probe_for_priming_result
 
-    RESTORE_GCODE_STATE VARIABLE=probe_for_priming_state
+    RESTORE_GCODE_STATE NAME=probe_for_priming_state
   {% endif %}
 
 [gcode_macro RESET_PRIME_PROBE_STATE]
@@ -714,8 +728,8 @@ gcode:
       {% set probe_y_step = (max_y - min_y) / probe_count_y %}
 
       # calculate xy probe count
-      {% set mesh_count_x = ([(mesh_x1 - mesh_x0) / probe_x_step, 3]|min)|int %}
-      {% set mesh_count_y = ([(mesh_y1 - mesh_y0) / probe_y_step, 3]|min)|int %}
+      {% set mesh_count_x = ([(mesh_x1 - mesh_x0) / probe_x_step, 3]|max)|int %}
+      {% set mesh_count_y = ([(mesh_y1 - mesh_y0) / probe_y_step, 3]|max)|int %}
       {% set min_mesh_count = [mesh_count_x, mesh_count_y]|min %}
       {% set max_mesh_count = [mesh_count_x, mesh_count_y]|max %}
 

--- a/macros.cfg
+++ b/macros.cfg
@@ -52,6 +52,7 @@ variable_safe_home_y: "middle"
 variable_stowable_probe_stop_on_error: False
 variable_driver_type_x: "tmc2209"
 variable_driver_type_y: "tmc2209"
+variable_adaptive_mesh: False
 gcode:
   ECHO_RATOS_VARS
 
@@ -106,7 +107,7 @@ gcode:
   {% else %}
     {action_respond_info("Extruder not hot enough")}
   {% endif %}
-  RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1
+  RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1 MOVE_SPEED={printer["gcode_macro RatOS"].macro_travel_speed|float}
   RESUME_BASE
 
 [gcode_macro CANCEL_PRINT]
@@ -390,7 +391,7 @@ gcode:
   # Run the user created "START_PRINT_BED_MESH" macro
   _USER_START_PRINT_BED_MESH
   # Run the customizable "BED_MESH" macro
-  _START_PRINT_BED_MESH
+  _START_PRINT_BED_MESH X0={params.X0} X1={params.X1} Y0={params.Y0} Y1={params.Y1}
   {% if printer["gcode_macro RatOS"].z_probe|lower == 'stowable' %}
   STOWABLE_PROBE_END_BATCH
   {% endif %}
@@ -445,7 +446,11 @@ gcode:
   {% set default_profile = printer["gcode_macro RatOS"].bed_mesh_profile|default('ratos') %}
   {% if printer["gcode_macro RatOS"].calibrate_bed_mesh|lower == 'true' %}
     BED_MESH_CLEAR
-    BED_MESH_CALIBRATE PROFILE={default_profile}
+    {% if printer["gcode_macro RatOS"].adaptive_mesh|lower == 'true' %}
+      CALIBRATE_ADAPTIVE_MESH PROFILE={default_profile} X0={params.X0} X1={params.X1} Y0={params.Y0} Y1={params.Y1}
+    {% else %}
+      BED_MESH_CALIBRATE PROFILE={default_profile}
+    {% endif %}
     BED_MESH_PROFILE LOAD={default_profile}
   {% elif printer["gcode_macro RatOS"].bed_mesh_profile is defined %}
     BED_MESH_CLEAR
@@ -467,11 +472,18 @@ gcode:
 
 [gcode_macro _START_PRINT_AFTER_HEATING_EXTRUDER]
 gcode:
+	{% set has_offset = printer["gcode_macro RatOS"].probe_for_priming_result|float(9999.9) != 9999.9 %}
+  {% if has_offset %}
+    ADD_PRIME_PROBE_TO_OFFSET
+  {% endif %}
   {% if printer["gcode_macro RatOS"].nozzle_priming|lower == 'primeline' %}
     PRIME_LINE
   {% endif %}
   {% if printer["gcode_macro RatOS"].nozzle_priming|lower == 'primeblob' %}
     PRIME_BLOB
+  {% endif %}
+  {% if has_offset %}
+    SUBTRACT_PRIME_PROBE_FROM_OFFSET
   {% endif %}
   {% if printer["gcode_macro RatOS"].skew_profile is defined %}
     SKEW_PROFILE LOAD={printer["gcode_macro RatOS"].skew_profile}
@@ -575,3 +587,172 @@ gcode:
   
 [gcode_macro _USER_END_PRINT_PARK]
 gcode:
+
+#####
+# MESH MACROS
+####
+
+[gcode_macro SAVE_PROBE_RESULT]
+gcode:
+	{% set last_z = printer.probe.last_z_result %}
+	SET_GCODE_VARIABLE MACRO=RatOS VARIABLE={params.VARIABLE|default('last_z')} VALUE={last_z}
+
+[gcode_macro PROBE_FOR_PRIMING]
+gcode:
+  {% if printer["gcode_macro RatOS"].nozzle_priming|lower != 'false' %}
+    SAVE_GCODE_STATE NAME=probe_for_priming_state
+    RESPOND MSG="Probing the prime location.."
+    {% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
+    {% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
+    {% if printer["gcode_macro RatOS"].nozzle_prime_start_x|lower == 'min' %}
+      {% set x_start = 5 %}
+    {% elif printer["gcode_macro RatOS"].nozzle_prime_start_x|lower == 'max' %}
+      {% set x_start = printer.toolhead.axis_maximum.x - 5 %}
+    {% else %}
+      {% set x_start = printer["gcode_macro RatOS"].nozzle_prime_start_x|float %}
+    {% endif %}
+    {% if printer["gcode_macro RatOS"].nozzle_prime_start_y|lower == 'min' %}
+      {% set y_start = 5 %}
+    {% elif printer["gcode_macro RatOS"].nozzle_prime_start_y|lower == 'max' %}
+      {% set y_start = printer.toolhead.axis_maximum.y - 5 %}
+    {% else %}
+      {% set y_start = printer["gcode_macro RatOS"].nozzle_prime_start_y|float %}
+    {% endif %}
+    {% set z = printer.configfile.settings.bed_mesh.horizontal_move_z|float %}
+    # Absolute positioning
+    G90 
+    # Relative extrusion
+    M83
+    # Lift to horizontal_move_z
+    G0 Z{z} F{z_speed}
+    # move close to blob position
+    G1 X{x_start} Y{y_start} F{speed}
+    PROBE_CURRENT_POSITION
+    SAVE_PROBE_RESULT VARIABLE=probe_for_priming_result
+
+    RESTORE_GCODE_STATE VARIABLE=probe_for_priming_state
+  {% endif %}
+
+[gcode_macro RESET_PRIME_PROBE_STATE]
+gcode:
+  SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=probe_for_priming_result VALUE=None
+
+[gcode_macro PROBE_CURRENT_POSITION]
+gcode:
+  SAVE_GCODE_STATE NAME=probe_current_position_state
+  {% if printer["gcode_macro RatOS"].z_probe|lower == 'stowable' %}
+    ASSERT_PROBE_DEPLOYED
+  {% endif %}
+  PROBE SAMPLES=1
+  RESTORE_GCODE_STATE NAME=probe_current_position_state MOVE=1 MOVE_SPEED={printer["gcode_macro RatOS"].macro_travel_speed|float}
+
+[gcode_macro ADD_PRIME_PROBE_TO_OFFSET]
+gcode:
+	{% set last_z = printer["gcode_macro RatOS"].probe_for_priming_result|float(9999.9) %}
+  {% if last_z == 9999.9 %}
+    action_raise_error("No probe result found for prime area. This is likely a bug.")
+  {% endif %}
+	RESPOND MSG="ADD_PRIME_PROBE_TO_OFFSET: adjusting z offset by {printer.configfile.settings.probe.z_offset - last_z}"
+  SET_GCODE_OFFSET Z_ADJUST={printer.configfile.settings.probe.z_offset - last_z} MOVE=1
+
+[gcode_macro SUBTRACT_PRIME_PROBE_FROM_OFFSET]
+gcode:
+	{% set last_z = printer["gcode_macro RatOS"].probe_for_priming_result|float(9999.9) %}
+  {% if last_z == 9999.9 %}
+    action_raise_error("No probe result found for prime area. This is likely a bug.")
+  {% endif %}
+	RESPOND MSG="SUBTRACT_PRIME_PROBE_FROM_OFFSET: adjusting z offset by {last_z - printer.configfile.settings.probe.z_offset}"
+  SET_GCODE_OFFSET Z_ADJUST={last_z - printer.configfile.settings.probe.z_offset} MOVE=1
+
+[gcode_macro CALIBRATE_ADAPTIVE_MESH]
+gcode:
+  # get default mesh profile
+  {% set default_profile = params.PROFILE %}
+
+  # coordinates from the slicer start gcode
+  {% set x0 = params.X0|default(-1)|float %}
+  {% set y0 = params.Y0|default(-1)|float %}
+  {% set x1 = params.X1|default(-1)|float %}
+  {% set y1 = params.Y1|default(-1)|float %}
+  RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: Recieved coordinates X0={x0} Y0={y0} X1={x1} Y1={y1}"
+
+  {% if x0 >= x1 or y0 >= y1 %}
+    # coordinates are invalid, fall back to full bed mesh
+    RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: Invalid coordinates received. Please check your slicer settings. Falling back to full bed mesh."
+    BED_MESH_CALIBRATE PROFILE={default_profile} 
+  {% else %}
+    # get bed mesh config object
+    {% set mesh_config = printer.configfile.config.bed_mesh %}
+
+    # get configured bed mesh area
+    {% set min_x = mesh_config.mesh_min.split(",")[0]|float %}
+    {% set min_y = mesh_config.mesh_min.split(",")[1]|float %}
+    {% set max_x = mesh_config.mesh_max.split(",")[0]|float %}
+    {% set max_y = mesh_config.mesh_max.split(",")[1]|float %}
+
+    # make sure mesh coordinates lie within the configured mesh area
+    {% set mesh_x0 = [[x0, max_x]|min, min_x]|max %}
+    {% set mesh_y0 = [[y0, max_y]|min, min_y]|max %}
+    {% set mesh_x1 = [[x1, max_x]|min, min_x]|max %}
+    {% set mesh_y1 = [[y1, max_y]|min, min_y]|max %}
+
+    {% if mesh_x0 == min_x and mesh_y0 == min_y and mesh_x1 == max_x and mesh_y1 == max_y %}
+      # coordinates are invalid, fall back to full bed mesh
+      RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: Print is using the full bed, falling back to full bed mesh."
+      BED_MESH_CALIBRATE PROFILE={default_profile}
+    {% else %}
+      # get configured probe count
+      {% set probe_count_x = mesh_config.probe_count.split(",")[0]|int %}
+      {% if mesh_config.probe_count.split(",")|length == 2 %}
+          {% set probe_count_y = mesh_config.probe_count.split(",")[1]|int %}
+      {% else %}
+          {% set probe_count_y = mesh_config.probe_count.split(",")[0]|int %}
+      {% endif %}
+
+      # calculate mesh point resolution
+      {% set probe_x_step = (max_x - min_x) / probe_count_x %}
+      {% set probe_y_step = (max_y - min_y) / probe_count_y %}
+
+      # calculate xy probe count
+      {% set mesh_count_x = ([(mesh_x1 - mesh_x0) / probe_x_step, 3]|min)|int %}
+      {% set mesh_count_y = ([(mesh_y1 - mesh_y0) / probe_y_step, 3]|min)|int %}
+      {% set min_mesh_count = [mesh_count_x, mesh_count_y]|min %}
+      {% set max_mesh_count = [mesh_count_x, mesh_count_y]|max %}
+
+      # check algorithms
+      {% set algorithm = mesh_config.algorithm %}
+      {% if algorithm|lower == 'lagrange' and max_mesh_count > 6 %}
+        RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: cannot exceed a probe_count of 6 when using lagrange interpolation. Falling back to bicubic interpolation."
+        {% set algorithm = 'bicubic' %}
+      {% endif %}
+      {% if algorithm|lower == 'bicubic' and min_mesh_count < 4 %}
+        {% if max_mesh_count > 6 %}
+          RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: invalid probe_count option when using bicubic interpolation. Combination of 3 points on one axis with more than 6 on another is not permitted. Forcing minimum mesh count to be 4."
+          {% set min_mesh_count = 4 %}
+        {% else %}
+          RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: bicubic interpolation with a probe_count of less than 4 points detected. Forcing lagrange interpolation."
+          {% set algorithm = 'lagrange' %}
+        {% endif %}
+      {% endif %}
+
+      # reset gcode variables
+      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=start_x VALUE=-1
+      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=start_y VALUE=-1
+      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=end_x VALUE=-1
+      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=end_y VALUE=-1
+
+      {% set prime_first = printer["gcode_macro RatOS"].nozzle_prime_start_y|lower == "min" or printer["gcode_macro RatOS"].nozzle_prime_start_y|float(printer.toolhead.axis_maximum.y) < printer.toolhead.axis_maximum.y / 2 %}
+
+      {% if prime_first %}
+        PROBE_FOR_PRIMING
+      {% endif %}
+      # mesh
+      RESPOND MSG="CALIBRATE_ADAPTIVE_MESH: mesh coordinates X0={mesh_x0} Y0={mesh_y0} X1={mesh_x1} Y1={mesh_y1}"
+      BED_MESH_CALIBRATE PROFILE={default_profile} algorithm={algorithm} mesh_min={mesh_x0},{mesh_y0} mesh_max={mesh_x1},{mesh_y1} probe_count={mesh_count_x},{mesh_count_y} relative_reference_index=-1
+      
+      {% if not prime_first %}
+        PROBE_FOR_PRIMING
+      {% endif %}
+
+    {% endif %}
+  {% endif %}

--- a/macros.cfg
+++ b/macros.cfg
@@ -735,12 +735,6 @@ gcode:
         {% endif %}
       {% endif %}
 
-      # reset gcode variables
-      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=start_x VALUE=-1
-      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=start_y VALUE=-1
-      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=end_x VALUE=-1
-      SET_GCODE_VARIABLE MACRO=MESH_CONFIG VARIABLE=end_y VALUE=-1
-
       {% set prime_first = printer["gcode_macro RatOS"].nozzle_prime_start_y|lower == "min" or printer["gcode_macro RatOS"].nozzle_prime_start_y|float(printer.toolhead.axis_maximum.y) < printer.toolhead.axis_maximum.y / 2 %}
 
       {% if prime_first %}

--- a/macros.cfg
+++ b/macros.cfg
@@ -644,7 +644,7 @@ gcode:
     ASSERT_PROBE_DEPLOYED
   {% endif %}
   PROBE SAMPLES=1
-  RESTORE_GCODE_STATE NAME=probe_current_position_state MOVE=1 MOVE_SPEED={printer["gcode_macro RatOS"].macro_travel_speed|float}
+  RESTORE_GCODE_STATE NAME=probe_current_position_state MOVE=1 MOVE_SPEED={printer["gcode_macro RatOS"].macro_z_speed|float}
 
 [gcode_macro ADD_PRIME_PROBE_TO_OFFSET]
 gcode:

--- a/z-probe/stowable-probe.cfg
+++ b/z-probe/stowable-probe.cfg
@@ -52,11 +52,11 @@ gcode:
     ## "open"      -> 0 :: probe deployed
     {% set last_query_state = "stowed" if printer.probe.last_query == 1 else "deployed" %}
 
-    {% if params.MUST_BE != last_query_state %}
+    {% if params.TO_BE != last_query_state %}
         {% if printer["gcode_macro RatOS"].stowable_probe_stop_on_error|lower == 'true' %}
-            { action_emergency_stop("expected probe state to be {} but is {} ({})".format(params.MUST_BE, last_query_state, printer.probe.last_query)) }
+            { action_emergency_stop("expected probe state to be {} but is {} ({})".format(params.TO_BE, last_query_state, printer.probe.last_query)) }
         {% else %}
-            { action_raise_error("expected probe state to be {} but is {} ({})".format(params.MUST_BE, last_query_state, printer.probe.last_query)) }
+            { action_raise_error("expected probe state to be {} but is {} ({})".format(params.TO_BE, last_query_state, printer.probe.last_query)) }
         {% endif %}
     {% else %}
         ## all good; update state
@@ -71,7 +71,7 @@ gcode:
     G4 P100
 
     QUERY_PROBE
-    _ASSERT_PROBE_STATE MUST_BE=deployed
+    _ASSERT_PROBE_STATE TO_BE=deployed
 
 [gcode_macro ASSERT_PROBE_STOWED]
 description: error if probe not stowed
@@ -81,7 +81,7 @@ gcode:
     G4 P100
 
     QUERY_PROBE
-    _ASSERT_PROBE_STATE MUST_BE=stowed
+    _ASSERT_PROBE_STATE TO_BE=stowed
 
 [gcode_macro STOWABLE_PROBE_BEGIN_BATCH]
 description: Begin stowable probe batch mode
@@ -190,7 +190,11 @@ rename_existing: BED_MESH_CALIBRATE_ORIG
 gcode:
     {% set args = [] %}
     {% for p in params %}
-        {% set tmp = args.append('%s=%s' % (p, params[p])) %}
+        {% if p == 'PROFILE' %}
+            {% set tmp = args.append('%s="%s"' % (p, params[p])) %}
+        {% else %}
+            {% set tmp = args.append('%s=%s' % (p, params[p])) %}
+        {% endif %}
     {% endfor %}
     DEPLOY_PROBE
     BED_MESH_CALIBRATE_ORIG {args|join(' ')} 
@@ -212,6 +216,17 @@ gcode:
     SAVE_GCODE_STATE name=probe_calibrate
     STOW_PROBE
     RESTORE_GCODE_STATE name=probe_calibrate MOVE=1 MOVE_SPEED={RatOS.macro_travel_speed|float}
+
+    
+[gcode_macro PROBE]
+rename_existing: PROBE_ORIG
+gcode:
+    {% set args = [] %}
+    {% for p in params %}
+        {% set tmp = args.append('%s=%s' % (p, params[p])) %}
+    {% endfor %}
+    ASSERT_PROBE_DEPLOYED
+    PROBE_ORIG {args|join(' ')}
 
 [gcode_macro PROBE_ACCURACY]
 rename_existing: PROBE_ACCURACY_ORIG


### PR DESCRIPTION
A simpler, jinja only successor to PAM, counterpart to KAMP. Does not require object processing, works by passing coordinates from the slicer, like PAM. Prime area is probed instead of moved.

Current state: seems to be working