### PR TITLE
Only call BED_MESH_CLEAR in END_PRINT if bed mesh calibration enabled

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -545,8 +545,10 @@ gcode:
 	M84
 	# Part cooling fan off
 	M107
-	# Clear bed mesh so that G28 doesn't fail.
-	BED_MESH_CLEAR
+	{% if printer["gcode_macro RatOS"].calibrate_bed_mesh|lower == 'true' %}
+		# Clear bed mesh so that G28 doesn't fail.
+		BED_MESH_CLEAR
+	{% endif %}
 	M117 Done :)
 	RESPOND MSG="Done :)"
 	RESTORE_GCODE_STATE NAME=end_print_state


### PR DESCRIPTION
Make code consistent with other similar parts
Fixes `Unknown command:"BED_MESH_CLEAR"` for users without bed mesh (like Voron 0)