### PR TITLE
Fix bootloop with ADXL connected

### DIFF
--- a/boards/btt-manta-m8p-11/config.cfg
+++ b/boards/btt-manta-m8p-11/config.cfg
@@ -62,7 +62,7 @@ min_temp: 0
 max_temp: 100
 
 [adxl345]
-spi_software_mosi_pin: stepper_spi_mosi_pin
-spi_software_miso_pin: stepper_spi_miso_pin
+spi_software_mosi_pin: stepper_spi_miso_pin
+spi_software_miso_pin: stepper_spi_mosi_pin
 spi_software_sclk_pin: stepper_spi_sclk_pin
 cs_pin: adxl345_cs_pin


### PR DESCRIPTION
The MISO and MOSI pins must be swapped to prevent a boot loop https://github.com/bigtreetech/Manta-M8P/issues/27

This contradicts the docs, and the wires of the sensor must also be swapped from the reference implementation, but it works.