### PR TITLE
Add rawparams to user macro hooks

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -207,7 +207,7 @@ gcode:
 	{% endif %}
 	{% if chamber_temp > 0 %}
 		_START_PRINT_HEAT_CHAMBER CHAMBER_TEMP={chamber_temp} BED_TEMP={start_print_heat_chamber_bed_temp}
-		_USER_START_PRINT_HEAT_CHAMBER CHAMBER_TEMP={chamber_temp} BED_TEMP={start_print_heat_chamber_bed_temp} { rawparams }
+		_USER_START_PRINT_HEAT_CHAMBER { rawparams } CHAMBER_TEMP={chamber_temp} BED_TEMP={start_print_heat_chamber_bed_temp}
 	{% endif %}
 	RATOS_ECHO MSG="Heating bed..."
 	# Wait for bed to heat up
@@ -217,7 +217,7 @@ gcode:
 	# Run the customizable "AFTER_HEATING_BED" macro.
 	_START_PRINT_AFTER_HEATING_BED T={initial_tool} BOTH_TOOLHEADS={both_toolheads}
 	# Run the user created "START_PRINT_BED_MESH" macro
-	_USER_START_PRINT_BED_MESH X0={X0} X1={X1} Y0={Y0} Y1={Y1} { rawparams }
+	_USER_START_PRINT_BED_MESH { rawparams } X0={X0} X1={X1} Y0={Y0} Y1={Y1}
 	# Run the customizable "BED_MESH" macro
 	_START_PRINT_BED_MESH X0={X0} X1={X1} Y0={Y0} Y1={Y1} T={initial_tool} BOTH_TOOLHEADS={both_toolheads} IDEX_MODE={idex_mode}
 	# handle stowable probe
@@ -260,7 +260,7 @@ gcode:
 		{% endif %}
 	{% endif %}
 	# Run the user created "AFTER_HEATING_EXTRUDER" macro.
-	_USER_START_PRINT_AFTER_HEATING_EXTRUDER X0={X0} X1={X1} Y0={Y0} Y1={Y1} { rawparams }
+	_USER_START_PRINT_AFTER_HEATING_EXTRUDER { rawparams } X0={X0} X1={X1} Y0={Y0} Y1={Y1}
 	# Run the customizable "AFTER_HEATING_EXTRUDER" macro.
 	_START_PRINT_AFTER_HEATING_EXTRUDER X0={X0} X1={X1} Y0={Y0} Y1={Y1} INITIAL_TOOLHEAD={initial_tool} BOTH_TOOLHEADS={both_toolheads} IDEX_MODE={idex_mode}
 	RATOS_ECHO MSG="Printing..."

--- a/macros.cfg
+++ b/macros.cfg
@@ -194,7 +194,7 @@ gcode:
 	G90 
 	# Set extruder to absolute mode
 	M82
-	_USER_START_PRINT_BEFORE_HOMING
+	_USER_START_PRINT_BEFORE_HOMING { rawparams }
 	# handle stowable probe
 	{% if z_probe_stowable == true %}
 		STOWABLE_PROBE_BEGIN_BATCH
@@ -207,17 +207,17 @@ gcode:
 	{% endif %}
 	{% if chamber_temp > 0 %}
 		_START_PRINT_HEAT_CHAMBER CHAMBER_TEMP={chamber_temp} BED_TEMP={start_print_heat_chamber_bed_temp}
-		_USER_START_PRINT_HEAT_CHAMBER CHAMBER_TEMP={chamber_temp} BED_TEMP={start_print_heat_chamber_bed_temp}
+		_USER_START_PRINT_HEAT_CHAMBER CHAMBER_TEMP={chamber_temp} BED_TEMP={start_print_heat_chamber_bed_temp} { rawparams }
 	{% endif %}
 	RATOS_ECHO MSG="Heating bed..."
 	# Wait for bed to heat up
 	M190 S{bed_temp}
 	# Run the user created "AFTER_HEATING_BED" macro
-	_USER_START_PRINT_AFTER_HEATING_BED
+	_USER_START_PRINT_AFTER_HEATING_BED { rawparams }
 	# Run the customizable "AFTER_HEATING_BED" macro.
 	_START_PRINT_AFTER_HEATING_BED T={initial_tool} BOTH_TOOLHEADS={both_toolheads}
 	# Run the user created "START_PRINT_BED_MESH" macro
-	_USER_START_PRINT_BED_MESH X0={X0} X1={X1} Y0={Y0} Y1={Y1}
+	_USER_START_PRINT_BED_MESH X0={X0} X1={X1} Y0={Y0} Y1={Y1} { rawparams }
 	# Run the customizable "BED_MESH" macro
 	_START_PRINT_BED_MESH X0={X0} X1={X1} Y0={Y0} Y1={Y1} T={initial_tool} BOTH_TOOLHEADS={both_toolheads} IDEX_MODE={idex_mode}
 	# handle stowable probe
@@ -244,7 +244,7 @@ gcode:
 		{% endif %}
 	{% endif %}
 	# Run the users "PARK" macro
-	_USER_START_PRINT_PARK
+	_USER_START_PRINT_PARK { rawparams }
 	# Run the customizable "PARK" macro
 	_START_PRINT_PARK
 	# Wait for extruder to heat up
@@ -260,7 +260,7 @@ gcode:
 		{% endif %}
 	{% endif %}
 	# Run the user created "AFTER_HEATING_EXTRUDER" macro.
-	_USER_START_PRINT_AFTER_HEATING_EXTRUDER X0={X0} X1={X1} Y0={Y0} Y1={Y1}
+	_USER_START_PRINT_AFTER_HEATING_EXTRUDER X0={X0} X1={X1} Y0={Y0} Y1={Y1} { rawparams }
 	# Run the customizable "AFTER_HEATING_EXTRUDER" macro.
 	_START_PRINT_AFTER_HEATING_EXTRUDER X0={X0} X1={X1} Y0={Y0} Y1={Y1} INITIAL_TOOLHEAD={initial_tool} BOTH_TOOLHEADS={both_toolheads} IDEX_MODE={idex_mode}
 	RATOS_ECHO MSG="Printing..."
@@ -429,12 +429,12 @@ gcode:
 		# IDEX - reset is_printing_gcode state
 		SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=is_printing_gcode VALUE=False
 	{% endif %}
-	_USER_END_PRINT_BEFORE_HEATERS_OFF
+	_USER_END_PRINT_BEFORE_HEATERS_OFF { rawparams }
 	_END_PRINT_BEFORE_HEATERS_OFF
 	TURN_OFF_HEATERS
-	_USER_END_PRINT_AFTER_HEATERS_OFF
+	_USER_END_PRINT_AFTER_HEATERS_OFF { rawparams }
 	_END_PRINT_AFTER_HEATERS_OFF
-	_USER_END_PRINT_PARK
+	_USER_END_PRINT_PARK { rawparams }
 	_END_PRINT_PARK
 	# Clear skew profile if any was loaded.
 	{% if printer["gcode_macro RatOS"].skew_profile is defined %}


### PR DESCRIPTION
Pass all parameters from the calling macro to the USER* macro hooks. This is useful if you want to pass custom parameters (e.g. to START_PRINT) and have them interpreted in the custom macro hooks.