### PR TITLE
Added optional variable to control M84 (motors off) at the end of the…

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -440,7 +440,7 @@ gcode:
 	{% if printer["gcode_macro RatOS"].skew_profile is defined %}
 		SET_SKEW CLEAR=1
 	{% endif %}
-	{% if printer["dual_carriage"] is not defined %}
+	{% if printer["dual_carriage"] is not defined and printer["gcode_macro RatOS"].end_print_motors_off|lower != 'false' %}
 		# COREXY - HYBRID
 		M84
 	{% endif %}
@@ -450,7 +450,7 @@ gcode:
 	BED_MESH_CLEAR
 	RATOS_ECHO MSG="Done :)"
 	RESTORE_GCODE_STATE NAME=end_print_state
-	{% if printer["dual_carriage"] is defined %}
+	{% if printer["dual_carriage"] is defined and printer["gcode_macro RatOS"].end_print_motors_off|lower != 'false' %}
 		# IDEX
 		# for the IDEX we must do this after RESTORE_GCODE_STATE
 		M84

--- a/macros/util.cfg
+++ b/macros/util.cfg
@@ -59,6 +59,7 @@ variable_printable_x_min: 0
 variable_printable_x_max: 0
 variable_printable_y_min: 0
 variable_printable_y_max: 0
+variable_end_print_motors_off: True
 gcode:
 	ECHO_RATOS_VARS
 


### PR DESCRIPTION
New variable to control M84 behavior (motors off) at the end of the print. Defaulted to True for same behavior.

Check for "!= false" in the odd case the variable isn't defined. Let me know if that's unnecessary. Also let me know if you'd rather the check be broken out of the corexy/idex check and nested.
