### PR TITLE
Allow klipper-mcu-added.sh to send a RESTART command to the printer

### DIFF
--- a/scripts/klipper-mcu-added.sh
+++ b/scripts/klipper-mcu-added.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 logfile="/var/log/ratos.log"
-mainsail="http://localhost:7125/"
-printer="/tmp/printer"
+moonraker="http://localhost:7125/"
+printer="/home/pi/printer_data/comms/klippy.serial"
 
 touch "$logfile"
 chmod 664 "$logfile"
@@ -9,7 +9,7 @@ chmod 664 "$logfile"
 echo "$(date +"%Y-%m-%d %T"): MCU Detected" >> "$logfile"
 
 # Query moonraker to get printer state
-state=$(curl ${mainsail%/}/printer/info | \
+state=$(curl ${moonraker%/}/printer/info | \
     python3 -c "import sys, json; print(json.load(sys.stdin)['result']['state'])")
 echo State is \"${state}\"
 
@@ -30,7 +30,7 @@ done
 # Only proceed if state reported by moonraker is "shutdown"
 
 if [ -z "$state" ]; then 
-    echo "$(date +"%Y-%m-%d %T"): Error querying ${mainsail} or parsing response ${state}." >> "$logfile"
+    echo "$(date +"%Y-%m-%d %T"): Error querying ${moonraker} or parsing response ${state}." >> "$logfile"
 
 elif [ ${state} = shutdown ] || [ ${state} = error ]; then
 
@@ -41,5 +41,5 @@ elif [ ${state} = shutdown ] || [ ${state} = error ]; then
         echo "$(date +"%Y-%m-%d %T"): $printer does not exist" >> "$logfile"
     fi
 else
-    echo "$(date +"%Y-%m-%d %T"): Mainsail reported printer status of \"${state}\". Ignoring MCU detect event." >> "$logfile"
+    echo "$(date +"%Y-%m-%d %T"): Moonraker reported printer status of \"${state}\". Ignoring MCU detect event." >> "$logfile"
 fi

--- a/scripts/klipper-mcu-added.sh
+++ b/scripts/klipper-mcu-added.sh
@@ -1,9 +1,29 @@
 #!/bin/sh
 logfile="/var/log/ratos.log"
+printer="/tmp/printer"
 
-if [ -e /tmp/printer ]; then
-    echo "RESTART" > /tmp/printer
-fi
 touch "$logfile"
 chmod 664 "$logfile"
+
 echo "$(date +"%Y-%m-%d %T"): MCU Detected" >> "$logfile"
+
+# If [ -h $printer] is true but [ -e $printer is false ] $printer is probably
+# a symbolic link in a directory with the sticky bit set, or one of the links
+# in a chain of symlinks is in a directory with the sticky bit set.
+# In this case, it will not be possible to write to $printer if that symlink
+# it is owned by a different user. /tmp often has the sticky bit set. 
+#
+# Dereference and keep dereferencing until $printer points to a file or 
+# symlink to which the RESTART command can actually be written
+
+while [ ! -e $printer ] && [ -h $printer ]
+do
+    printer=$(readlink $printer)
+done
+
+if [ -e $printer ]; then
+    echo "RESTART" > $printer
+    echo "$(date +"%Y-%m-%d %T"): RESTART command sent to $printer" >> "$logfile"
+else
+    echo "$(date +"%Y-%m-%d %T"): $printer does not exist" >> "$logfile"
+fi


### PR DESCRIPTION
Allow klipper-mcu-added.sh to send a RESTART command to the printer, even if the printer file is a symlink in a directory with the sticky bit set. Improve logging

Symlinks cannot be followed if they are in a directory with the sticky bit set, like /tmp, if the symlink is owned by a different user.
This causes [ -e /tmp/printer ] to evaluate to false. This also means that trying to write to /tmp/printer fails unless the user owns the /tmp/printer symlink. 

Added a loop to keep dereferencing until either the -e test evaluates true or no longer testing a symlink.

With this change, powering up the MCU while klippy is running results in RESTART being sent to /tmp/printer and the printer becoming usable without any user intervention.