### PR TITLE
BEACON: setting contact_max_hotend_temperature to 275°C 

### DIFF
--- a/z-probe/beacon.cfg
+++ b/z-probe/beacon.cfg
@@ -19,7 +19,7 @@ mesh_main_direction: x
 mesh_runs: 1
 speed: 15.
 lift_speed: 80.
-#contact_max_hotend_temperature: 190
+contact_max_hotend_temperature: 275
 
 # TODO: remove when automatically calculated by configurator
 [bed_mesh]


### PR DESCRIPTION
this allows the user to use the beacon temperature expansion calibration macro