### PR TITLE
Remove beacon temp offset

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -1118,6 +1118,8 @@ gcode:
 	{% if printer["gcode_macro RatOS"].skew_profile is defined %}
 		SET_SKEW CLEAR=1
 	{% endif %}
+
+	# turn motors off for non idex printers
 	{% if printer["dual_carriage"] is not defined and printer["gcode_macro RatOS"].end_print_motors_off|lower != 'false' %}
 		# DEFAULT
 		M84
@@ -1132,6 +1134,8 @@ gcode:
 
 	# restore gcode state
 	RESTORE_GCODE_STATE NAME=end_print_state
+
+	# turn motors off for idex printers
 	{% if printer["dual_carriage"] is defined %}
 		# IDEX
 		# for the IDEX we must do this after RESTORE_GCODE_STATE
@@ -1140,11 +1144,7 @@ gcode:
 
 	# reset nozzle thermal expansion offset
 	{% if printer.configfile.settings.beacon is defined %}
-		# remove a previously applied expansion offset
-		{% if "xyz" in printer.toolhead.homed_axes %}
-			_BEACON_REMOVE_NOZZLE_TEMP_OFFSET
-		{% endif %} 
-		# reset nozzle thermal expansion offset
+		_BEACON_REMOVE_NOZZLE_TEMP_OFFSET
 		_BEACON_SET_NOZZLE_TEMP_OFFSET RESET=True
 	{% endif %}
 

--- a/macros/overrides.cfg
+++ b/macros/overrides.cfg
@@ -27,11 +27,6 @@ gcode:
 		_IDEX_SINGLE INIT=1
 	{% endif %}
 
-	# reset nozzle thermal expansion offset
-	{% if printer.configfile.settings.beacon is defined %}
-		_BEACON_SET_NOZZLE_TEMP_OFFSET RESET=True
-	{% endif %}
-
 	# visual feedback
 	_LED_MOTORS_OFF
 

--- a/z-probe/beacon.cfg
+++ b/z-probe/beacon.cfg
@@ -134,7 +134,7 @@ gcode:
 
 		# remove applied offset
 		{% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
-		SET_GCODE_OFFSET Z_ADJUST={(-applied_offset)} MOVE=1 SPEED={z_speed}
+		SET_GCODE_OFFSET Z_ADJUST={(-applied_offset)} MOVE=0 SPEED={z_speed}
 
 	{% endif %}
 

--- a/z-probe/beacon.cfg
+++ b/z-probe/beacon.cfg
@@ -19,7 +19,7 @@ mesh_main_direction: x
 mesh_runs: 1
 speed: 15.
 lift_speed: 80.
-#contact_max_hotend_temperature: 190
+contact_max_hotend_temperature: 275
 
 # TODO: remove when automatically calculated by configurator
 [bed_mesh]


### PR DESCRIPTION
makes sure the applied beacon nozzle temp offset gets removed after the print ends 