### PR TITLE
update LOAD_FILAMENT and UNLOAD_FILAMENT macros

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -299,9 +299,9 @@ gcode:
 	G91
 	{% if params.TEMP is defined or printer.extruder.can_extrude|lower == 'false' %}
 		M117 Heating...
-		# Heat up hotend to provided temp or 220 as default as that should work OK with most filaments.
-		M104 S{params.TEMP|default(220, true)}
-		TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(220, true)}
+		# Heat up hotend to provided temp or 250C as default as that should work OK with most filaments.
+		M104 S{params.TEMP|default(250, true)}
+		TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(250, true)}
 	{% endif %}
 	{% set unload_speed = printer["gcode_macro RatOS"].filament_unload_speed|float * 60 %}
 	{% set unload_length = printer["gcode_macro RatOS"].filament_unload_length|float %}
@@ -321,17 +321,21 @@ gcode:
 	M117 Filament unloaded!
 	RESPOND MSG="Filament unloaded! Please inspect the tip of the filament before reloading."
 	RESTORE_GCODE_STATE NAME=unload_state
+	# Cooling down to 180C to prevent oozing
+	M104 S{params.TEMP.ooz|default(180, true)}
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP.ooz|default(180, true)}
+	M117 Hotend cooled down to prevent oozing!
 
 [gcode_macro LOAD_FILAMENT]
 description: Loads new filament. Note: be careful with PETG, make sure you inspect the tip of your filament before loading to avoid jams.
 gcode:
 	SAVE_GCODE_STATE NAME=load_state
 	G91
-	# Heat up hotend to provided temp or 220 as default as that should work OK with most filaments.
+	# Heat up hotend to provided temp or 250C so it can load any filament, also purging any old material still in the nozzle.
 	{% if params.TEMP is defined or printer.extruder.can_extrude|lower == 'false' %}
 		M117 Heating...
-		M104 S{params.TEMP|default(220, true)}
-		TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(220, true)}
+		M104 S{params.TEMP|default(250, true)}
+		TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(250, true)}
 	{% endif %}
 	{% set load_speed = printer["gcode_macro RatOS"].filament_load_speed|float * 60 %}
 	{% set load_length = printer["gcode_macro RatOS"].filament_load_length|float %}
@@ -347,6 +351,10 @@ gcode:
 	M117 Filament loaded!
 	RESPOND MSG="Filament loaded!"
 	RESTORE_GCODE_STATE NAME=load_state
+	# Cooling down to 180C to prevent oozing
+    M104 S{params.TEMP.ooz|default(180, true)}
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP.ooz|default(180, true)}
+    M117 Hotend cooled down to prevent oozing!
 
 [gcode_macro SET_CENTER_KINEMATIC_POSITION]
 description: FOR DEBUGGING PURPOSES ONLY. Sets the internal printer kinematic state to the center of all axes regardless of actual physical position.


### PR DESCRIPTION
Currently, the LOAD_FILAMENT and UNLOAD_FILAMENT macros in Klipper heat the hotend to 220°C, which is suitable for PLA but may not be optimal for other materials like PETG. 

When using PETG, the extruder has to work much harder than necessary.

However, BambuLab machines employ a more advanced logic. They heat the hotend to 250°C for any type of material, regardless of what is currently being loaded. 

This is because it's crucial to melt not only the new filament but also any material that may have been left in the nozzle from the previous print (could be ASA, PLA, ABS, PC...).

After loading or unloading the filament, the hotend starts cooling down to 180°C to prevent oozing, which is another smart feature.

I have personally implemented this macro on my RatRig machines, and it has worked flawlessly. I believe it can greatly benefit the RatRig community as well, and I'm excited to share it with you.