### PR TITLE
PROBE_FOR_PRIMING macro: ensure the probe Z is above the bed

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -634,14 +634,21 @@ gcode:
 		{% if printer.configfile.settings.bltouch is defined %}
 			{% set x_offset = printer.configfile.settings.bltouch.x_offset|float %}
 			{% set y_offset = printer.configfile.settings.bltouch.y_offset|float %}
+			{% set z_offset = printer.configfile.settings.bltouch.z_offset|float %}
 		{% elif printer.configfile.settings.probe is defined %}
 			{% set x_offset = printer.configfile.settings.probe.x_offset|float %}
 			{% set y_offset = printer.configfile.settings.probe.y_offset|float %}
+			{% set z_offset = printer.configfile.settings.probe.z_offset|float %}
 		{% elif printer.configfile.settings.beacon is defined %}
 			{% set x_offset = printer.configfile.settings.beacon.x_offset|float %}
 			{% set y_offset = printer.configfile.settings.beacon.y_offset|float %}
+			{% set z_offset = printer.configfile.settings.beacon.trigger_distance|float %}
 		{% else %}
 			{ action_raise_error("No probe or bltouch section found. Adaptive priming only works with [probe] or [bltouch].") }
+		{% endif %}
+
+		{% if z < z_offset %}
+			{ action_raise_error("Horizontal move Z is below your probe's Z offset. Please adjust your horizontal_move_z setting in [bed_mesh].") }
 		{% endif %}
 
 		# get configured bed mesh area


### PR DESCRIPTION
To avoid probe-bed crash, check safe Z distance before movement