### PR TITLE
FR: Add simultaneous Z-move when approaching priming location

### DIFF
--- a/macros/priming.cfg
+++ b/macros/priming.cfg
@@ -418,7 +418,7 @@ gcode:
 	{% if printer["dual_carriage"] is not defined %}
 		# DEFAULT
 		RATOS_ECHO PREFIX="Priming" MSG="Moving to {x_start}, {y_start} along the edge of the print area.."
-		G1 X{x_start} F{speed}
+		G1 X{x_start} Z1 F{speed}
 		G1 Y{y_start + (15 * y_factor)} F{speed}
 	{% else %}
 		# IDEX
@@ -430,7 +430,7 @@ gcode:
 		{% else %}
 			RATOS_ECHO PREFIX="Priming" MSG="Moving to {x_start}, {y_start} along the edge of the print area.."
 		{% endif %}
-		G1 X{x_start} F{speed}
+		G1 X{x_start} Z1 F{speed}
 	{% endif %}
 
 	RATOS_ECHO PREFIX="Priming" MSG="Starting prime blob.."

--- a/macros/priming.cfg
+++ b/macros/priming.cfg
@@ -418,7 +418,7 @@ gcode:
 	{% if printer["dual_carriage"] is not defined %}
 		# DEFAULT
 		RATOS_ECHO PREFIX="Priming" MSG="Moving to {x_start}, {y_start} along the edge of the print area.."
-		G1 X{x_start} Z1 F{speed}
+		G1 X{x_start} Z15 F{speed} # Move simultaneously Z to lay down oozed filament, but high enough not to collide with old prime_blob
 		G1 Y{y_start + (15 * y_factor)} F{speed}
 	{% else %}
 		# IDEX


### PR DESCRIPTION
to allow lay down oozed filament from the nozzle next to prime location instead of smudge(?) all over the nozzle (where it is often remains sticked and dragged over bed when print already started and this string being released in the least convenient moment).
It greatly helps against it.

(IDEX part isn't tested, I have single carriage)