### PR TITLE
Update moonraker.conf update_manager KlipperScreen to new dependencie…

### DIFF
--- a/moonraker.conf
+++ b/moonraker.conf
@@ -82,10 +82,11 @@ managed_services:
 [update_manager KlipperScreen]
 type: git_repo
 path: ~/KlipperScreen
-origin: https://github.com/jordanruthe/KlipperScreen.git
-env: ~/.KlipperScreen-env/bin/python
+origin: https://github.com/KlipperScreen/KlipperScreen.git
+virtualenv: ~/.KlipperScreen-env
 requirements: scripts/KlipperScreen-requirements.txt
-install_script: scripts/KlipperScreen-install.sh
+system_dependencies: scripts/system-dependencies.json
+managed_services: KlipperScreen
 
 [update_manager beacon]
 type: git_repo


### PR DESCRIPTION
…s as per KlipperScreen documentation

Removed old references that throw errors on startup since the new version of KlipperScreen