### PR TITLE
Update config.cfg to include z1 and z2 instead of extruder which is used from toolboard

### DIFF
--- a/boards/btt-manta-m5p/config.cfg
+++ b/boards/btt-manta-m5p/config.cfg
@@ -11,7 +11,8 @@ aliases:
   x_step_pin=PC8,   x_dir_pin=PC9,   x_enable_pin=PA15,  x_uart_pin=PD9,   x_diag_pin=PD3,   x_endstop_pin=PD3,
   y_step_pin=PA10,  y_dir_pin=PA14,  y_enable_pin=PA13,  y_uart_pin=PD8,   y_diag_pin=PD2,   y_endstop_pin=PD2,
   z0_step_pin=PC6,  z0_dir_pin=PC7,  z0_enable_pin=PA9,  z0_uart_pin=PB10, z0_diag_pin=null,
-  e_step_pin=PB0,  e_dir_pin=PB1,  e_enable_pin=PC4,  e_uart_pin=PA6,  e_diag_pin=null, e_heater_pin=PC5,  e_sensor_pin=PA1,
+  z1_step_pin=PB12,  z1_dir_pin=PB11,  z1_enable_pin=PA8,  z1_uart_pin=PB2, z1_diag_pin=null,
+  z2_step_pin=PB0,  z2_dir_pin=PB1,  z2_enable_pin=PC4,  z2_uart_pin=PA6, z2_diag_pin=null,
   stepper_spi_mosi_pin=PB15, stepper_spi_miso_pin=PB14,  stepper_spi_sclk_pin=PB13,
 # accel
   adxl345_cs_pin=PC0,


### PR DESCRIPTION
When configuring a VCore3 or 4 the configuration is missing configuration for z1 and z2. In the configurator it states that when using this board a toolboard is required. Going through the steps and choosing the motors for z1 and z2 works fine, but at the last step it fails since there were no configurations defined for z1 and z2.  This fixes that issue.