### PR TITLE
Beacon: clean up redundancies and prevent overwriting models which disabled z-offset adjustments.

### DIFF
--- a/homing.cfg
+++ b/homing.cfg
@@ -191,7 +191,7 @@ gcode:
 				DEPLOY_PROBE
 				G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				{% if printer.configfile.settings.beacon is defined and beacon_contact_z_homing %}
-					BEACON_AUTO_CALIBRATE  
+					BEACON_AUTO_CALIBRATE SKIP_MODEL_CREATION=1
 					G0 Z{z_hop} F{z_hop_speed}
 					G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				{% else %}
@@ -202,7 +202,7 @@ gcode:
 			{% else %}
 				G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				{% if printer.configfile.settings.beacon is defined and beacon_contact_z_homing %}
-					BEACON_AUTO_CALIBRATE  
+					BEACON_AUTO_CALIBRATE SKIP_MODEL_CREATION=1
 					G0 Z{z_hop} F{z_hop_speed}
 					G0 X{safe_home_x} Y{safe_home_y} F{speed}
 				{% else %}

--- a/macros.cfg
+++ b/macros.cfg
@@ -839,32 +839,31 @@ gcode:
 		{% endif %}
 	{% endif %}
 
-	# park beacon for heat soaking
-	{% if printer.configfile.settings.beacon is defined and beacon_contact_z_calibration %}
-		{% if printer["dual_carriage"] is defined and act_t != default_toolhead %}
-			_SELECT_TOOL T={default_toolhead} X={safe_home_x} Y={safe_home_y} TOOLSHIFT=True
-		{% endif %}
-		RATOS_ECHO MSG="Heat soaking beacon..."
-		{% if auto_z_offset_calibration %}
-			{% set safe_distance = printer.configfile.settings.dual_carriage.safe_distance|float %}
-			{% if default_toolhead == 0 %}
-				_SELECT_TOOL T=0 TOOLSHIFT=false
-				G1 X{safe_home_x - safe_distance / 2} F{speed}
-				SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
-				G1 X{safe_home_x + safe_distance / 2} F{speed}
-				SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
-			{% elif default_toolhead == 1 %}
-				_SELECT_TOOL T=1 TOOLSHIFT=false
-				G1 X{safe_home_x + safe_distance / 2} F{speed}
-				SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
-				G1 X{safe_home_x - safe_distance / 2} F{speed}
-				SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
-			{% endif %}
-		{% else %}
-			G0 X{safe_home_x} Y{safe_home_y} F{speed}
-		{% endif %}
-		G0 Z2 F{z_speed}
+	# park toolhead in the center at Z=2 for heat soaking
+	{% if printer["dual_carriage"] is defined and act_t != default_toolhead %}
+		_SELECT_TOOL T={default_toolhead} X={safe_home_x} Y={safe_home_y} TOOLSHIFT=True
 	{% endif %}
+	RATOS_ECHO MSG="Heat soaking beacon..."
+	{% if auto_z_offset_calibration %}
+		{% set safe_distance = printer.configfile.settings.dual_carriage.safe_distance|float %}
+		{% if default_toolhead == 0 %}
+			_SELECT_TOOL T=0 TOOLSHIFT=false
+			G1 X{safe_home_x - safe_distance / 2} F{speed}
+			SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
+			G1 X{safe_home_x + safe_distance / 2} F{speed}
+			SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
+		{% elif default_toolhead == 1 %}
+			_SELECT_TOOL T=1 TOOLSHIFT=false
+			G1 X{safe_home_x + safe_distance / 2} F{speed}
+			SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
+			G1 X{safe_home_x - safe_distance / 2} F{speed}
+			SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
+		{% endif %}
+	{% else %}
+		G0 X{safe_home_x} Y{safe_home_y} F{speed}
+	{% endif %}
+	# Always soak close to first layer height.
+	G0 Z2 F{z_speed}
 
 
 [gcode_macro _START_PRINT_AFTER_HEATING_BED]
@@ -966,18 +965,10 @@ gcode:
 
 	# Home again as Z will have changed after automatic bed leveling and bed heating.
 	{% if needs_rehoming %}
-		G0 Z{z_hop} F{z_hop_speed}
-		G0 X{safe_home_x} Y{safe_home_y} F{speed}
-		{% if printer.configfile.settings.beacon is defined and beacon_contact_z_homing %}
-			BEACON_AUTO_CALIBRATE  
-			G0 Z{z_hop} F{z_hop_speed}
-			G0 X{safe_home_x} Y{safe_home_y} F{speed}
-		{% else %}
-			G28 Z
-		{% endif %}
+		G28 Z
 	{% endif %}
 
-	# beacon contact z-calibration with model creating
+	# beacon contact z-calibration with model creation
 	{% if printer.configfile.settings.beacon is defined and beacon_contact_z_calibration %}
 		{% if beacon_contact_wipe_before_calibrate %}
 			_START_PRINT_AFTER_HEATING_BED_PROBE_FOR_WIPE

--- a/z-probe/beacon.cfg
+++ b/z-probe/beacon.cfg
@@ -31,9 +31,11 @@ mesh_min: 20,30
 [gcode_macro RatOS]
 variable_beacon_bed_mesh_scv: 25                        # square corner velocity for bed meshing with proximity method
 variable_beacon_contact_z_homing: False                 # printer z-homing with contact method
-variable_beacon_contact_z_calibration: True             # contact z-calibration before the print starts
+variable_beacon_contact_z_calibration: False            # contact z-calibration before the print starts
                                                         # after changing this variable please run a recalibration before you use the printer  
 												        # if you use a smooth PEI sheet turn this feature off
+														# This feature effectively disables saving of z-offset, as a new model will be created for each print
+														# Hotend expansion compensation can still be adjusted using `SAVE_Z_OFFSET`
 
 variable_beacon_contact_calibration_location: "center"  # center = center of the build plate
                                                         # front = front center
@@ -866,11 +868,6 @@ gcode:
 				G4 P{(bed_heat_soak_time * 1000)}
 			{% endif %}
 		{% endif %}
-		
-		# auto calibrate beacon 
-		{% if not automated %}
-			BEACON_AUTO_CALIBRATE
-		{% endif %}
 
 		# create contact mesh
 		BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES=2 SAMPLES_DROP=1 SAMPLES_TOLERANCE_RETRIES=10 PROBE_COUNT={probe_count[0]},{probe_count[1]} PROFILE={profile}
@@ -974,27 +971,8 @@ gcode:
 
 	# Home again as Z will have changed after automatic bed leveling.
 	{% if needs_rehoming %}
-		G0 Z{z_hop} F{z_hop_speed}
-		G0 X{safe_home_x} Y{safe_home_y} F{speed}
-		{% if printer.configfile.settings.beacon is defined and beacon_contact_z_homing %}
-			BEACON_AUTO_CALIBRATE  
-			G0 Z{z_hop} F{z_hop_speed}
-			G0 X{safe_home_x} Y{safe_home_y} F{speed}
-		{% else %}
-			G28 Z
-		{% endif %}
+		G28 Z
 	{% endif %}
-
-	# beacon autocalibration
-	G0 Z{z_hop} F{z_speed}
-	G0 X{safe_home_x} Y{safe_home_y} F{speed}
-	G0 Z5 F{z_speed}
-	BEACON_AUTO_CALIBRATE
-
-	# move back to home position
-	G0 Z{z_hop} F{z_speed}
-	G0 X{safe_home_x} Y{safe_home_y} F{speed}
-
 
 [gcode_macro _BEACON_SAVE_MULTIPLIER]
 gcode:


### PR DESCRIPTION
There were an excessive amount of redundant `BEACON_AUTO_CALIBRATE` commands and move commands, and every one of them was creating new models, effectively causing z_offset to be cleared every time the printer was homed, or a print was started (up to 5 models created here...).

Furthermore i've disabled contact_z_calibration by default, is that intentionally creates a new model, but also effectively results in z-offset being overwritten.