### PR TITLE
Beacon: rectify the model creation confusion.

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -305,7 +305,7 @@ gcode:
 	{% endif %}
 
 	# beacon contact config
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 
 	# get macro parameters
 	{% set X0 = params.X0|default(-1)|float %}
@@ -574,7 +574,7 @@ gcode:
 	G1 Z{z_hop} F{z_speed}
 
 	# move toolhead to the oozeguard if needed
-	{% if idex_mode != '' and not (printer.configfile.settings.beacon is defined and beacon_contact_z_calibration) %}
+	{% if idex_mode != '' and not (printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero) %}
 		PARK_TOOLHEAD
 	{% endif %}
 
@@ -623,10 +623,10 @@ gcode:
 	{% if idex_mode == '' %}
 		SET_HEATER_TEMPERATURE HEATER="extruder" TARGET={extruder_first_layer_temp[0]|float}
 	{% else %}
-		{% if initial_tool == 0 or both_toolheads or (default_toolhead == 0 and printer.configfile.settings.beacon is defined and beacon_contact_z_calibration) %}
+		{% if initial_tool == 0 or both_toolheads or (default_toolhead == 0 and printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero) %}
 			SET_HEATER_TEMPERATURE HEATER="extruder" TARGET={extruder_first_layer_temp[0]|float}
 		{% endif %}
-		{% if initial_tool == 1 or both_toolheads or (default_toolhead == 1 and printer.configfile.settings.beacon is defined and beacon_contact_z_calibration) %}
+		{% if initial_tool == 1 or both_toolheads or (default_toolhead == 1 and printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero) %}
 			SET_HEATER_TEMPERATURE HEATER="extruder1" TARGET={extruder_first_layer_temp[1]|float}
 		{% endif %}
 	{% endif %}
@@ -642,10 +642,10 @@ gcode:
 	{% if idex_mode == '' %}
 		TEMPERATURE_WAIT SENSOR="extruder" MINIMUM={extruder_first_layer_temp[0]|float}  MAXIMUM={extruder_first_layer_temp[0]|float + 5}
 	{% else %}
-		{% if initial_tool == 0 or both_toolheads or (default_toolhead == 0 and printer.configfile.settings.beacon is defined and beacon_contact_z_calibration) %}
+		{% if initial_tool == 0 or both_toolheads or (default_toolhead == 0 and printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero) %}
 			TEMPERATURE_WAIT SENSOR="extruder" MINIMUM={extruder_first_layer_temp[0]|float}  MAXIMUM={extruder_first_layer_temp[0]|float + 5}
 		{% endif %}
-		{% if initial_tool == 1 or both_toolheads or (default_toolhead == 1 and printer.configfile.settings.beacon is defined and beacon_contact_z_calibration) %}
+		{% if initial_tool == 1 or both_toolheads or (default_toolhead == 1 and printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero) %}
 			TEMPERATURE_WAIT SENSOR="extruder1" MINIMUM={extruder_first_layer_temp[1]|float}  MAXIMUM={extruder_first_layer_temp[1]|float + 5}
 		{% endif %}
 	{% endif %}
@@ -820,7 +820,7 @@ gcode:
 	{% endif %}
 
 	# beacon contact config
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 
 	# preheat extruder
 	{% if printer["gcode_macro RatOS"].preheat_extruder|lower == 'true' %}
@@ -905,9 +905,8 @@ gcode:
 	{% endif %}
 
 	# beacon contact config
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
-	{% set beacon_contact_z_homing = true if printer["gcode_macro RatOS"].beacon_contact_z_homing|default(false)|lower == 'true' else false %}
-	{% set beacon_contact_wipe_before_calibrate = true if printer["gcode_macro RatOS"].beacon_contact_wipe_before_calibrate|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
+	{% set variable_beacon_contact_wipe_before_true_zero = true if printer["gcode_macro RatOS"].variable_beacon_contact_wipe_before_true_zero|default(false)|lower == 'true' else false %}
 
 	# wait for extruder to be preheated
 	{% if printer["gcode_macro RatOS"].preheat_extruder|lower == 'true' %}
@@ -964,16 +963,16 @@ gcode:
 	{% endif %}
 
 	# Home again as Z will have changed after automatic bed leveling and bed heating.
-	{% if needs_rehoming %}
+	{% if needs_rehoming and not printer.configfile.settings.beacon is defined and not beacon_contact_start_print_true_zero %}
 		G28 Z
 	{% endif %}
 
-	# beacon contact z-calibration with model creation
-	{% if printer.configfile.settings.beacon is defined and beacon_contact_z_calibration %}
-		{% if beacon_contact_wipe_before_calibrate %}
+	# beacon contact homing with optional wipe
+	{% if printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero %}
+		{% if variable_beacon_contact_wipe_before_true_zero %}
 			_START_PRINT_AFTER_HEATING_BED_PROBE_FOR_WIPE
 		{% endif %}
-		_START_PRINT_AFTER_HEATING_BED_CALIBRATE_Z
+		_START_PRINT_AFTER_HEATING_CONTACT_WITH_OPTIONAL_WIPE
 	{% endif %}
 
 
@@ -992,7 +991,7 @@ gcode:
 	BEACON_QUERY
 
 
-[gcode_macro _START_PRINT_AFTER_HEATING_BED_CALIBRATE_Z]
+[gcode_macro _START_PRINT_AFTER_HEATING_CONTACT_WITH_OPTIONAL_WIPE]
 gcode:
 	# config
 	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
@@ -1010,32 +1009,14 @@ gcode:
 	{% endif %}
 
 	# beacon contact config
-	{% set beacon_contact_calibration_temp = printer["gcode_macro RatOS"].beacon_contact_calibration_temp|default(150)|int %}
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
-	{% set beacon_contact_z_homing = true if printer["gcode_macro RatOS"].beacon_contact_z_homing|default(false)|lower == 'true' else false %}
-	{% set beacon_contact_calibration_location = printer["gcode_macro RatOS"].beacon_contact_calibration_location|default("front")|lower %}
-	{% set beacon_contact_calibrate_margin_x = printer["gcode_macro RatOS"].beacon_contact_calibrate_margin_x|default(30)|int %}
-	{% set beacon_contact_wipe_before_calibrate = true if printer["gcode_macro RatOS"].beacon_contact_wipe_before_calibrate|default(false)|lower == 'true' else false %}
-	{% if printer.configfile.settings.beacon is defined %}
-		# get calibration x position
-		{% set safe_z_calibration_margin_y = 5 %}
-		{% if beacon_contact_calibration_location == "center" %}
-			{% set safe_z_calibration_x = safe_home_x %}
-			{% set safe_z_calibration_y = safe_home_y %}
-		{% elif beacon_contact_calibration_location == "front" %}
-			{% set safe_z_calibration_x = safe_home_x %}
-			{% set safe_z_calibration_y = safe_z_calibration_margin_y + printer.configfile.config.beacon.y_offset|float %}
-		{% elif beacon_contact_calibration_location == "corner" %}
-			{% set safe_z_calibration_x = beacon_contact_calibrate_margin_x %}
-			{% if printer["dual_carriage"] is defined and default_toolhead == 1 %}
-				{% set safe_z_calibration_x = printable_x_max - beacon_contact_calibrate_margin_x %}
-			{% endif %}
-			{% set safe_z_calibration_y = safe_z_calibration_margin_y + printer.configfile.config.beacon.y_offset|float %}
-		{% endif %}
-	{% endif %}
+	{% set beacon_contact_true_zero_temp = printer["gcode_macro RatOS"].beacon_contact_true_zero_temp|default(150)|int %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_true_zero_location = printer["gcode_macro RatOS"].beacon_contact_true_zero_location|default("front")|lower %}
+	{% set beacon_contact_true_zero_margin_x = printer["gcode_macro RatOS"].beacon_contact_true_zero_margin_x|default(30)|int %}
+	{% set variable_beacon_contact_wipe_before_true_zero = true if printer["gcode_macro RatOS"].variable_beacon_contact_wipe_before_true_zero|default(false)|lower == 'true' else false %}
 
 	# wipe before z-calibration
-	{% if beacon_contact_wipe_before_calibrate %}
+	{% if variable_beacon_contact_wipe_before_true_zero %}
 		{% if printer.beacon.last_probe_result|lower == "ok" %}
 			{% set last_z_offset = printer.beacon.last_z_result %}
 			RATOS_ECHO MSG="Auto calibration nozzle wipe with probe result {last_z_offset}..."
@@ -1048,14 +1029,14 @@ gcode:
 
 	# moving to safe z-calibration position
 	G0 Z5 F{z_speed}
-	G0 X{safe_z_calibration_x} Y{safe_z_calibration_y} F{speed}
+	G0 X{safe_home_x} Y{safe_home_y} F{speed}
 	# set probing toolhead to probing temperature
 	RATOS_ECHO MSG="Heating extruder to probing temperature..."
-	SET_HEATER_TEMPERATURE HEATER={"extruder" if default_toolhead == 0 else "extruder1"} TARGET={beacon_contact_calibration_temp}
-	TEMPERATURE_WAIT SENSOR={"extruder" if default_toolhead == 0 else "extruder1"} MINIMUM={beacon_contact_calibration_temp} MAXIMUM={beacon_contact_calibration_temp + 5}
+	SET_HEATER_TEMPERATURE HEATER={"extruder" if default_toolhead == 0 else "extruder1"} TARGET={beacon_contact_true_zero_temp}
+	TEMPERATURE_WAIT SENSOR={"extruder" if default_toolhead == 0 else "extruder1"} MINIMUM={beacon_contact_true_zero_temp} MAXIMUM={beacon_contact_true_zero_temp + 5}
 	# auto calibration
 	RATOS_ECHO MSG="Beacon contact auto calibration..."
-	BEACON_AUTO_CALIBRATE
+	BEACON_AUTO_CALIBRATE SKIP_MODEL_CREATION=1
 	# raise z
 	G0 Z5 F{z_speed}
 
@@ -1277,9 +1258,9 @@ gcode:
 	{% if printer.configfile.settings.beacon is defined %}
 		{% if printer["dual_carriage"] is not defined %}
 			# beacon config
-			{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+			{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 			{% set beacon_contact_expansion_compensation = true if printer["gcode_macro RatOS"].beacon_contact_expansion_compensation|default(false)|lower == 'true' else false %}
-			{% if beacon_contact_z_calibration and beacon_contact_expansion_compensation %}
+			{% if beacon_contact_start_print_true_zero and beacon_contact_expansion_compensation %}
 				SET_GCODE_OFFSET Z=0 MOVE=0
 			{% endif %}
 		{% endif %}

--- a/macros/idex/vaoc.cfg
+++ b/macros/idex/vaoc.cfg
@@ -658,9 +658,9 @@ gcode:
 	{% set is_started = true if printer["gcode_macro _VAOC"].is_started|default(false)|lower == 'true' else false %}
 
 	# beacon contact config
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 
-	{% if is_fixed and is_started and printer["z_offset_probe"] is defined and printer.configfile.settings.beacon is defined and beacon_contact_z_calibration %}
+	{% if is_fixed and is_started and printer["z_offset_probe"] is defined and printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero %}
 
 		# config
 		{% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}

--- a/macros/parking.cfg
+++ b/macros/parking.cfg
@@ -26,7 +26,7 @@ gcode:
 	{% endif %}
 
 	# park IDEX toolhead if needed
-	{% if printer["dual_carriage"] is defined and not (printer.configfile.settings.beacon is defined and beacon_contact_z_calibration) %}
+	{% if printer["dual_carriage"] is defined and not (printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero) %}
 		{% if printer["gcode_macro RatOS"].start_print_park_x is defined and printer["gcode_macro RatOS"].start_print_park_x != '' %}
 			RATOS_ECHO PREFIX="WARNING" MSG="start_print_park_x is ignored for IDEX printers"
 		{% endif %}

--- a/z-probe/beacon.cfg
+++ b/z-probe/beacon.cfg
@@ -30,29 +30,25 @@ mesh_min: 20,30
 #####
 [gcode_macro RatOS]
 variable_beacon_bed_mesh_scv: 25                        # square corner velocity for bed meshing with proximity method
-variable_beacon_contact_z_homing: False                 # printer z-homing with contact method
-variable_beacon_contact_z_calibration: False            # contact z-calibration before the print starts
-                                                        # after changing this variable please run a recalibration before you use the printer  
-												        # if you use a smooth PEI sheet turn this feature off
-														# This feature effectively disables saving of z-offset, as a new model will be created for each print
-														# Hotend expansion compensation can still be adjusted using `SAVE_Z_OFFSET`
+variable_beacon_contact_z_homing: False                 # Make all G28 calls use contact instead of proximity scan
+variable_beacon_contact_start_print_true_zero: True     # Use contact to determine true Z=0 for the last homing move during START_PRINT
+variable_beacon_contact_wipe_before_true_zero: True     # enables a nozzle wipe at Y10 before true zeroing
+variable_beacon_contact_true_zero_temp: 150             # nozzle temperature for true zeroing
+                                                        # WARNING: if you're using a smooth PEI sheet, be careful with the temperature
 
-variable_beacon_contact_calibration_location: "center"  # center = center of the build plate
-                                                        # front = front center
-														# corner = front corner
+variable_beacon_contact_prime_probing: True             # probe for priming with contact method
+variable_beacon_contact_expansion_compensation: True    # enables the nozzle thermal expansion compensation
 
-variable_beacon_contact_calibrate_margin_x: 30          # x-margin if calibrate in front corners
 variable_beacon_contact_bed_mesh: False                 # bed mesh with contact method
 variable_beacon_contact_bed_mesh_samples: 2             # probe samples for contact bed mesh
+
 variable_beacon_contact_z_tilt_adjust: False            # z-tilt adjust with contact method
 variable_beacon_contact_z_tilt_adjust_samples: 2        # probe samples for contact z-tilt adjust
-variable_beacon_contact_prime_probing: True             # probe for priming with contact method
-variable_beacon_contact_calibration_temp: 150           # nozzle temperature for auto calibration
-variable_beacon_contact_expansion_compensation: True    # enables the nozzle thermal expansion compensation
-variable_beacon_contact_wipe_before_calibrate: True     # enables a nozzle wipe at Y0 before doing the contact calibration
+
 variable_beacon_scan_compensation_enable: False         # Enables the beacon scan compensation
 variable_beacon_scan_compensation_profile: "Contact"    # The contact profile name for the scan compensation
 variable_beacon_scan_compensation_probe_count: 15,15    # The contact probe count for the scan compensation
+
 variable_beacon_contact_poke_bottom_limit: -1		    # The bottom limit for the contact poke test
 
 
@@ -435,9 +431,9 @@ gcode:
 	{% set poke_bottom = printer["gcode_macro RatOS"].beacon_contact_poke_bottom_limit|default(-1)|float %}
 
 	# beacon config
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 
-	{% if beacon_contact_z_calibration %}
+	{% if beacon_contact_start_print_true_zero %}
 
 		# home and abl the printer if needed  
 		_BEACON_HOME_AND_ABL
@@ -579,8 +575,8 @@ gcode:
 	{% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
 
 	# beacon config
-	{% set beacon_contact_calibration_temp = printer["gcode_macro RatOS"].beacon_contact_calibration_temp|default(150)|int %}
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_true_zero_temp = printer["gcode_macro RatOS"].beacon_contact_true_zero_temp|default(150)|int %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 	{% set beacon_contact_expansion_compensation = true if printer["gcode_macro RatOS"].beacon_contact_expansion_compensation|default(false)|lower == 'true' else false %}
 
 	# ratos variables file
@@ -591,7 +587,7 @@ gcode:
 		SAVE_VARIABLE VARIABLE=nozzle_expansion_applied_offset VALUE=0
 
 	{% else %}
-		{% if beacon_contact_z_calibration and beacon_contact_expansion_compensation %}
+		{% if beacon_contact_start_print_true_zero and beacon_contact_expansion_compensation %}
 
 			# get coefficient
 			{% set nozzle_expansion_coefficient_t0 = svv.nozzle_expansion_coefficient_t0|default(0)|float %}
@@ -609,7 +605,7 @@ gcode:
 			{% set temp = printer['extruder' if toolhead == 0 else 'extruder1'].target|float %}
 
 			# calculate new offset
-			{% set temp_offset = temp - beacon_contact_calibration_temp %}
+			{% set temp_offset = temp - beacon_contact_true_zero_temp %}
 			{% set expansion_coefficient = nozzle_expansion_coefficient_t0 if toolhead == 0 else nozzle_expansion_coefficient_t1 %}
 			{% set expansion_offset = nozzle_expansion_coefficient_multiplier * (temp_offset * (expansion_coefficient / 100)) %}
 
@@ -661,9 +657,9 @@ gcode:
 	{% set poke_bottom = printer["gcode_macro RatOS"].beacon_contact_poke_bottom_limit|default(-1)|float %}
 
 	# beacon config
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 
-	{% if beacon_contact_z_calibration %}
+	{% if beacon_contact_start_print_true_zero %}
 
 		# reset varaible  
 		SET_GCODE_VARIABLE MACRO=BEACON_MEASURE_GANTRY_TWIST VARIABLE=needs_compensation VALUE=False
@@ -977,13 +973,13 @@ gcode:
 [gcode_macro _BEACON_SAVE_MULTIPLIER]
 gcode:
 	# parameters
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 	{% set beacon_contact_expansion_compensation = true if printer["gcode_macro RatOS"].beacon_contact_expansion_compensation|default(false)|lower == 'true' else false %}
 	{% set multiplier = printer["gcode_macro _BEACON_APPLY_RUNTIME_MULTIPLIER"].runtime_multiplier|default(-1.0)|float %}
 
-	DEBUG_ECHO PREFIX="_BEACON_SAVE_MULTIPLIER" MSG="multiplier: {multiplier}, beacon_contact_z_calibration: {beacon_contact_z_calibration}, beacon_contact_expansion_compensation: {beacon_contact_expansion_compensation}"
+	DEBUG_ECHO PREFIX="_BEACON_SAVE_MULTIPLIER" MSG="multiplier: {multiplier}, beacon_contact_start_print_true_zero: {beacon_contact_start_print_true_zero}, beacon_contact_expansion_compensation: {beacon_contact_expansion_compensation}"
 
-	{% if multiplier > 0 and beacon_contact_z_calibration and beacon_contact_expansion_compensation %}
+	{% if multiplier > 0 and beacon_contact_start_print_true_zero and beacon_contact_expansion_compensation %}
 		SAVE_VARIABLE VARIABLE=nozzle_expansion_coefficient_multiplier VALUE={multiplier}
 		SET_GCODE_VARIABLE MACRO=_BEACON_APPLY_RUNTIME_MULTIPLIER VARIABLE=runtime_multiplier VALUE=-1.0
 		CONSOLE_ECHO TITLE="Hotend thermal expansion compensation" TYPE="success" MSG={'"New value is: %.6f_N_The new multiplier value has been saved to the configuration."' % multiplier}
@@ -1003,8 +999,8 @@ gcode:
 	{% endif %}
 
 	# beacon config
-	{% set beacon_contact_calibration_temp = printer["gcode_macro RatOS"].beacon_contact_calibration_temp|default(150)|int %}
-	{% set beacon_contact_z_calibration = true if printer["gcode_macro RatOS"].beacon_contact_z_calibration|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_true_zero_temp = printer["gcode_macro RatOS"].beacon_contact_true_zero_temp|default(150)|int %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
 	{% set beacon_contact_expansion_compensation = true if printer["gcode_macro RatOS"].beacon_contact_expansion_compensation|default(false)|lower == 'true' else false %}
 
 	# get current layer number
@@ -1020,9 +1016,9 @@ gcode:
 		CONSOLE_ECHO TITLE="Missing layer information" TYPE="warning" MSG={line_1}
 	{% endif %}
 
-	DEBUG_ECHO PREFIX="_BEACON_APPLY_RUNTIME_MULTIPLIER" MSG="layer_number: {layer_number}, is_printing_gcode: {is_printing_gcode}, beacon_contact_z_calibration: {beacon_contact_z_calibration}, beacon_contact_expansion_compensation: {beacon_contact_expansion_compensation}"
+	DEBUG_ECHO PREFIX="_BEACON_APPLY_RUNTIME_MULTIPLIER" MSG="layer_number: {layer_number}, is_printing_gcode: {is_printing_gcode}, beacon_contact_start_print_true_zero: {beacon_contact_start_print_true_zero}, beacon_contact_expansion_compensation: {beacon_contact_expansion_compensation}"
 	
-	{% if layer_number == 1 and is_printing_gcode and printer.configfile.settings.beacon is defined and beacon_contact_z_calibration and beacon_contact_expansion_compensation %}
+	{% if layer_number == 1 and is_printing_gcode and printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero and beacon_contact_expansion_compensation %}
 
 		# ratos variables file
 		{% set svv = printer.save_variables.variables %}
@@ -1039,7 +1035,7 @@ gcode:
 
 		{% if print_temp > 0 %}
 			{% set z_offset = printer.gcode_move.homing_origin.z|float %}
-			{% set temp_delta = print_temp - beacon_contact_calibration_temp %}
+			{% set temp_delta = print_temp - beacon_contact_true_zero_temp %}
 			{% set coefficient_per_degree = nozzle_expansion_coefficient / 100 %}
 			{% set z_offset_per_degree = z_offset / temp_delta %}
 			{% set new_multiplier = z_offset_per_degree / coefficient_per_degree %}


### PR DESCRIPTION
"contact_calibrate_z" has been renamed to "true_zero", which is now enabled by default. This mechanism no longer generates a new model, it just executes a final home Z using contact with an optional wipe before hand (enabled by default) during the start_print process, to ensure the Z=0 is the same everytime a print is started. Model z_offset is still applied if present.

Furthermore, true zero position now follows safe_home position.