### PR TITLE
Fix Prusa Einsy Pin Configuration

### DIFF
--- a/boards/prusa-einsy/config.cfg
+++ b/boards/prusa-einsy/config.cfg
@@ -10,7 +10,7 @@
 aliases:
 # steppers
   x_step_pin=PC0,   x_dir_pin=PL0,   x_enable_pin=PA7, x_diag_pin=PK2, x_uart_pin=PG0, x_endstop_pin=PK2,
-  y_step_pin=PC1,   y_dir_pin=PL1,    y_enable_pin=PA6, y_diag_pin=PK7, y_uart_pin=PG2, y_endstop_pin=PK7
+  y_step_pin=PC1,   y_dir_pin=PL1,    y_enable_pin=PA6, y_diag_pin=PK7, y_uart_pin=PG2, y_endstop_pin=PK7,
   z0_step_pin=PC2,   z0_dir_pin=PL2,    z0_enable_pin=PA5, z0_diag_pin=PK6, z0_uart_pin=PK5,
   e_step_pin=PC3,   e_dir_pin=PL6,    e_enable_pin=PA4, e_diag_pin=PK3, e_uart_pin=PK4, e_heater_pin=PE5,  e_sensor_pin=PF0,
 # auto leveling


### PR DESCRIPTION
Hi folks,

the Prusy Einsy Pin Config is missing a Comma :-)

Best,

OXERY