### PR TITLE
PLUGIN: outcomment new sample_drop feature since it breaks VAOC

### DIFF
--- a/klippy/z_offset_probe.py
+++ b/klippy/z_offset_probe.py
@@ -168,9 +168,9 @@ class ZOffsetProbe:
         while len(positions) < sample_count:
             # Probe position
             pos = self._probe(speed)
-            if samples_drop > 0:
-                samples_drop -= 1
-                continue
+            # if samples_drop > 0:
+            #     samples_drop -= 1
+            #     continue
             positions.append(pos)
             # Check samples tolerance
             z_positions = [p[2] for p in positions]


### PR DESCRIPTION
current change breaks VAOC since the nozzle stops on the button instead of be raised