### PR TITLE
Macros: use zero_reference_position when using beacon true zero

### DIFF
--- a/macros.cfg
+++ b/macros.cfg
@@ -306,6 +306,7 @@ gcode:
 
 	# beacon contact config
 	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
+	{% set beacon_contact_calibrate_model_on_print = true if printer["gcode_macro RatOS"].beacon_contact_calibrate_model_on_print|default(false)|lower == 'true' else false %}
 
 	# get macro parameters
 	{% set X0 = params.X0|default(-1)|float %}
@@ -606,6 +607,13 @@ gcode:
 	{% if bed_heat_soak_time > 0 %}
 		RATOS_ECHO MSG="Heat soaking bed for {bed_heat_soak_time} seconds..."
 		G4 P{(bed_heat_soak_time * 1000)}
+	{% endif %}
+
+	
+	# Calibrate a new beacon model on print if enabled
+	{% if printer.configfile.settings.beacon is defined and beacon_contact_calibrate_model_on_print %}
+		_MOVE_TO_SAFE_Z_HOME
+		BEACON_AUTO_CALIBRATE
 	{% endif %}
 
 	# Run the user created "AFTER_HEATING_BED" macro

--- a/macros.cfg
+++ b/macros.cfg
@@ -611,9 +611,13 @@ gcode:
 
 	
 	# Calibrate a new beacon model on print if enabled
-	{% if printer.configfile.settings.beacon is defined and beacon_contact_calibrate_model_on_print %}
+	{% if printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero %}
 		_MOVE_TO_SAFE_Z_HOME
-		BEACON_AUTO_CALIBRATE
+		{% if beacon_contact_calibrate_model_on_print %}
+			BEACON_AUTO_CALIBRATE
+		{% else %}
+			BEACON_AUTO_CALIBRATE SKIP_MODEL_CREATION=1
+		{% endif %}
 	{% endif %}
 
 	# Run the user created "AFTER_HEATING_BED" macro

--- a/macros/mesh.cfg
+++ b/macros/mesh.cfg
@@ -227,9 +227,9 @@ gcode:
 			# mesh
 			RATOS_ECHO PREFIX="Adaptive Mesh" MSG="mesh coordinates X0={mesh_x0} Y0={mesh_y0} X1={mesh_x1} Y1={mesh_y1}"
 			{% if printer.configfile.settings.beacon is defined and beacon_contact_bed_mesh %}
-				BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
+				BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y}
 			{% else %}
-				BED_MESH_CALIBRATE PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
+				BED_MESH_CALIBRATE PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y}
 				{% if printer.configfile.settings.beacon is defined %}
 					_BEACON_APPLY_SCAN_COMPENSATION
 				{% endif %}

--- a/macros/mesh.cfg
+++ b/macros/mesh.cfg
@@ -10,6 +10,27 @@
 variable_calibrate_bed_mesh: True                # True|False = enable bed meshing
 variable_adaptive_mesh: True                     # True|False = enable adaptive bed meshing
 
+[gcode_macro _BED_MESH_SANITY_CHECK]
+gcode:
+	{% set printable_x_max = printer["gcode_macro RatOS"].printable_x_max|float %}
+	{% set printable_y_max = printer["gcode_macro RatOS"].printable_y_max|float %}
+	{% set safe_home_x = printer["gcode_macro RatOS"].safe_home_x %}
+	{% if safe_home_x is not defined or safe_home_x|lower == 'middle' %}
+		{% set safe_home_x = printable_x_max / 2 %}
+	{% endif %}
+	{% set safe_home_y = printer["gcode_macro RatOS"].safe_home_y %}
+	{% if safe_home_y is not defined or safe_home_y|lower == 'middle' %}
+		{% set safe_home_y = printable_y_max / 2 %}
+	{% endif %}
+	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
+
+	{% if printer.configfile.settings.beacon is defined and beacon_contact_start_print_true_zero %}
+		{% set zero_ref_pos = printer.configfile.settings.bed_mesh.zero_reference_position %}
+		{% if zero_ref_pos is not defined or zero_ref_pos[0] != safe_home_x or zero_ref_pos[1] != safe_home_y %}
+			CONSOLE_ECHO TYPE="error" TITLE="Zero reference position does not match safe home position" MSG="Please update your bed mesh zero reference position in printer.cfg, like so:_N_[bed_mesh]_N_zero_reference_position: {safe_home_x},{safe_home_y}"
+			_STOP_AND_RAISE_ERROR MSG="Zero reference position does not match safe home position"
+		{% endif %}
+	{% endif %}
 
 [gcode_macro _START_PRINT_BED_MESH]
 gcode:

--- a/macros/util.cfg
+++ b/macros/util.cfg
@@ -53,6 +53,7 @@ gcode:
 	CALCULATE_PRINTABLE_AREA
 	INITIAL_FRONTEND_UPDATE
 	_CHAMBER_FILTER_SANITY_CHECK
+	_BED_MESH_SANITY_CHECK
 
 
 [delayed_gcode RATOS_LOGO]
@@ -394,3 +395,14 @@ gcode:
 			SET_SKEW CLEAR=1
 		{% endif %}
 	{% endif %}
+
+
+[gcode_macro _RAISE_ERROR]
+gcode:
+	{ action_raise_error(params.MSG) }
+
+
+[gcode_macro _STOP_AND_RAISE_ERROR]
+gcode:
+	M84
+	_RAISE_ERROR MSG="{params.MSG}"

--- a/z-probe/beacon.cfg
+++ b/z-probe/beacon.cfg
@@ -36,6 +36,11 @@ variable_beacon_contact_wipe_before_true_zero: True     # enables a nozzle wipe 
 variable_beacon_contact_true_zero_temp: 150             # nozzle temperature for true zeroing
                                                         # WARNING: if you're using a smooth PEI sheet, be careful with the temperature
 
+variable_beacon_contact_calibrate_model_on_print: False # Calibrate a new beacon model every print, it's recommended to enable this if
+                                                        # if you're often swapping build plates with different surface types.
+														# NOTE: this effectively disables z_offset on the beacon model, since a new one
+														# will be calibrated every print (however a model offset should never be needed with contact probing)
+
 variable_beacon_contact_prime_probing: True             # probe for priming with contact method
 variable_beacon_contact_expansion_compensation: True    # enables the nozzle thermal expansion compensation
 


### PR DESCRIPTION
This prevents scanned meshes from being offset from the true zero position, which results in an unintended additional z_offset to be applied via the incorrect bed mesh.