### PR TITLE
MACRO: add M601 gcode command

### DIFF
--- a/macros/util.cfg
+++ b/macros/util.cfg
@@ -394,3 +394,8 @@ gcode:
 			SET_SKEW CLEAR=1
 		{% endif %}
 	{% endif %}
+
+
+[gcode_macro M601]
+gcode:
+	PAUSE


### PR DESCRIPTION
Current public ratrig slicer profiles do use M601 gcode command for Pause.